### PR TITLE
chore: land strategic vision v2.0 — Trinity flagship cut

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,14 +1,14 @@
 {
   "name": "nixtla-plugins",
   "owner": {
-    "name": "Intent Solutions",
-    "url": "https://github.com/intent-solutions-io"
+    "name": "Jeremy Longshore",
+    "url": "https://github.com/jeremylongshore"
   },
   "plugins": [
     {
       "name": "nixtla-baseline-lab",
       "version": "1.5.0",
-      "source": "github:intent-solutions-io/plugins-nixtla/005-plugins/nixtla-baseline-lab",
+      "source": "github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-baseline-lab",
       "description": "Run Nixtla-style baseline forecasting models on public benchmark datasets from inside Claude Code conversations.",
       "author": {
         "name": "Jeremy Longshore",
@@ -20,7 +20,7 @@
     {
       "name": "nixtla-bigquery-forecaster",
       "version": "0.1.0",
-      "source": "github:intent-solutions-io/plugins-nixtla/005-plugins/nixtla-bigquery-forecaster",
+      "source": "github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-bigquery-forecaster",
       "description": "Run Nixtla statsforecast models on BigQuery time series data. Pull from BigQuery, forecast with AutoETS/AutoTheta, write results back.",
       "author": {
         "name": "Jeremy Longshore",
@@ -32,7 +32,7 @@
     {
       "name": "nixtla-search-to-slack",
       "version": "0.2.0",
-      "source": "github:intent-solutions-io/plugins-nixtla/005-plugins/nixtla-search-to-slack",
+      "source": "github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-search-to-slack",
       "description": "Automated content discovery and curation for Nixtla and time-series forecasting practitioners. Searches web and GitHub, generates AI summaries, and publishes formatted digests to Slack.",
       "author": {
         "name": "Jeremy Longshore",

--- a/000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md
+++ b/000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md
@@ -1,0 +1,212 @@
+# 130-AA-VISN — Strategic Vision v2.0: Flagship Curation
+
+| | |
+|---|---|
+| **Status** | Decided |
+| **Date** | 2026-05-02 (CST) |
+| **Decision owner** | Jeremy Longshore |
+| **Authors** | Jeremy Longshore, with Claude (Opus 4.7) acting as lead-tech / CTO |
+| **Supersedes** | The implicit "build everything" trajectory that produced 14 plugin directories from a 3-plugin marketplace |
+| **Anchors** | `.claude-plugin/marketplace.json`, `README.md`, `005-plugins/README.md`, `CHANGELOG.md`, beads `nixtla-*` |
+
+---
+
+## TL;DR
+
+**This repository ships *three* flagship plugins to the world, not fourteen.** Everything else is either the next-six-months revenue roadmap, deferred Y2 work, or scaffolding that gets explicitly demarcated as experimental and removed from the public-facing surface. The goal is not coverage; the goal is a globally-elite Nixtla showcase that any prospect, partner, or hiring manager can land on and immediately understand: this is what production-grade time-series forecasting with Claude Code looks like.
+
+---
+
+## What we decided
+
+1. **The marketplace is the truth.** The three plugins listed in `.claude-plugin/marketplace.json` (`nixtla-baseline-lab`, `nixtla-bigquery-forecaster`, `nixtla-search-to-slack`) are the v2.0 flagship — call this **The Trinity**. Everything else either earns its way onto the marketplace via the v3.0 roadmap or gets demarcated as experimental.
+2. **The Trinity ships at globally-elite quality before anything else gets attention.** That means: parameterized BigQuery, retry/backoff, real CI per plugin, formal pytest with coverage, screencasts, deployment guide for self-hosting, observability hooks. The bar is "a Fortune 500 user installs this, runs it on their data, and trusts the result enough to build downstream automation on it."
+3. **The v3.0 expansion is the three highest-revenue PRDs**, in order: `nixtla-sales-demo-builder` (3wk, sales acceleration), `nixtla-forecast-workflow-templates` (6wk, $50–100K ARR, flywheel), `nixtla-forecast-audit-report` (8wk, $100–200K ARR, regulated verticals). Each lands as its own minor release.
+4. **The Y2 flagship is `nixtla-embedded-forecast-widget`** (10–12wk, $200–500K Y2). Built only after Trinity + v3.0 are battle-tested with paying customers. Building this earlier is premature optimization.
+5. **Everything else is archived or marked experimental.** Eight PRD-missing plugins, two pure-internal tools (support-deflector, docs-qa-generator), one streaming greenfield (anomaly-streaming-monitor), and one warehouse SCAFFOLD (dbt-package) — all moved to an explicit experimental tier, not advertised to the world, not blocking the flagship release.
+
+---
+
+## Why we decided this
+
+### The three-identities problem
+
+Walking the repo today, three different versions of "what this is" are simultaneously visible:
+
+| Identity | Where it lives | Plugin count |
+|---|---|---|
+| **Original tight showcase** | `.claude-plugin/marketplace.json`, original README narrative | 3 |
+| **Organic drift** | `005-plugins/` directory | 14 |
+| **Aspirational roadmap** | `000-docs/000a-planned-plugins/` | 7 |
+
+The marketplace is the artifact users actually install from. It listed three plugins on the day the repo was made public, and it lists three plugins today. The 11 extra directories in `005-plugins/` are not products — they are early scaffolds that grew faster than they were finished, with stub READMEs (32–65 lines) and `.mcp.json` shells around thin handlers. Of the 10 PARTIAL plugins, only **two** have any meaningful product documentation (`changelog-automation` and `nixtla-bigquery-forecaster`). The rest were never intended to be public; they leaked through because nothing forced a tier distinction.
+
+### The "global elite" criterion
+
+The owner's question is: what would we present to the world? Not what could we present, what *would* we. The right answer is small, polished, narratively coherent, and verifiable. The wrong answer is "everything we've ever started." Quality is the thing that compounds; sprawl is the thing that decays. This decision optimizes for the compounding direction.
+
+### The revenue picture
+
+A read of all seven PRDs reveals three different value mechanisms:
+
+| Plugin | Value | Y1 projection |
+|---|---|---|
+| `nixtla-sales-demo-builder` | Direct sales acceleration | 20% cycle reduction, 10% win-rate lift |
+| `nixtla-forecast-audit-report` | Regulated-vertical unlock | $100–200K ARR + influenced revenue |
+| `nixtla-forecast-workflow-templates` | Flywheel (3× API consumption, 40% churn reduction) | $50–100K ARR |
+| `nixtla-embedded-forecast-widget` | Partner distribution / platform play | $200–500K Y2 |
+| `nixtla-support-deflector` | Internal cost reduction | $0 customer revenue |
+| `nixtla-docs-qa-generator` | Internal cost reduction | $0 customer revenue |
+| `changelog-automation` | Internal cost reduction | $0 customer revenue |
+
+Three of seven move the business; four don't. Building the four would be a service to ourselves, not to Nixtla or the world. They get explicit "deferred indefinitely" status — not because they're bad ideas, but because they aren't *this repo's job*. They could be re-spun as standalone Intent Solutions repos if internal demand materializes.
+
+### What the audit told us about quality
+
+State audits dispatched against the partial set returned a consistent signal: most "PARTIAL" plugins are actually closer to scaffolds than to working software.
+
+- `nixtla-search-to-slack`: misclassified — actually working (1.5K LOC, 5 pytest suites at 70–85% coverage, 24K SETUP_GUIDE, real integrations, existing PRD). Belongs in The Trinity, which is exactly where the marketplace already had it.
+- `nixtla-baseline-lab`: WORKING, grade A-. MCP server is 1925 lines with full type hints and real schemas; README is grade A. Gaps to elite: no CI per plugin, no formal pytest, no performance benchmarks, no screencast.
+- `nixtla-bigquery-forecaster`: demo-grade. Has Workload Identity auth (modern, good) and a real CI/CD pipeline. SQL-injection risk via f-string column names, no retry logic, no caching, no enterprise auth/deploy guide. ~2–3wk to elite.
+- `nixtla-dbt-package`: SCAFFOLD. Adapters all empty. 2–3wk with warehouse access.
+- `nixtla-anomaly-streaming-monitor`: pure scaffold; closer to greenfield than fix.
+- 8 PRD-missing partial plugins: thin MCP handlers + stub READMEs. None are "almost done."
+
+The audit confirmed what marketplace.json already implied: there are three real plugins here. The other eleven directories are unfinished thoughts.
+
+---
+
+## The four tiers
+
+### Tier 1 — The Trinity (v2.0 ship target)
+
+Three plugins, hardened to elite quality, shipped together as v2.0.
+
+| Plugin | Current grade | Hardening required |
+|---|---|---|
+| `nixtla-baseline-lab` | A− | Add per-plugin CI workflow; migrate homegrown smoke test to pytest with coverage; commit golden output CSVs + plots; record a 60-second screencast; add `examples/` with a runnable demo |
+| `nixtla-bigquery-forecaster` | demo-grade | Parameterize all column names in BigQuery queries (security); add exponential backoff for BQ quota errors; add Cloud Function timeout config; ship a Terraform/gcloud "deploy to your project" guide; add response-cache layer; surface query cost estimate in response |
+| `nixtla-search-to-slack` | working | Verify `claude plugin install` loads cleanly; wire skills as Claude Code skills; add optional Claude WebSearch fallback to drop SerpAPI cost; one real Slack-bot smoke test; close out the existing PRD's MVP checklist |
+
+**v2.0 acceptance criteria** (every Trinity plugin must pass):
+
+1. Loads via `claude plugin install` from a fresh clone of `jeremylongshore/plugins-nixtla` with zero local state.
+2. Per-plugin CI workflow runs on every PR, gates merge, and produces a coverage report.
+3. Formal pytest test suite with ≥80% line coverage on plugin code.
+4. README starts with a 30-second elevator + a copy-paste quickstart that produces a real result on a fresh machine in under 5 minutes.
+5. At least one runnable demo committed to `examples/` with a sample input and expected output.
+6. Security review passes (no f-string SQL, no plaintext secrets, retry logic on external APIs, timeouts on every blocking call).
+7. A 60–90 second screencast linked from the plugin README.
+8. Deploy / self-host guide if the plugin requires external infrastructure (BigQuery, Slack workspace).
+9. Listed in `.claude-plugin/marketplace.json` with version synced to plugin manifest.
+10. Linked from the root README's flagship section.
+
+### Tier 2 — Revenue plays (v3.0 expansion, sequenced)
+
+Three plugins, each shipped as its own minor release.
+
+| Plugin | Effort | Why this priority |
+|---|---|---|
+| `nixtla-sales-demo-builder` | 3 wk | Quick-win, smallest of the three, validates v2.0 build template under real load. Direct sales acceleration multiplier for Nixtla. |
+| `nixtla-forecast-workflow-templates` | 6 wk | Flywheel: 3× API consumption + 40% churn reduction. Converts demo users into sticky paying customers. $50–100K ARR. |
+| `nixtla-forecast-audit-report` | 8 wk | Unlocks regulated verticals (finance, healthcare, pharma). $100–200K ARR + unlocks $200–500K of currently-blocked deals. |
+
+Each lands as its own release (`v2.1.0`, `v2.2.0`, `v2.3.0`). Each must meet the v2.0 acceptance criteria (above) on its own before merging.
+
+### Tier 3 — Y2 flagship
+
+`nixtla-embedded-forecast-widget` — 10–12 wk, $200–500K Y2 ARR. Building this in 2026 instead of waiting for Trinity + v3.0 customer signal is premature optimization. Revisit in 2027 once we have at least three paying enterprise customers on Tier 2 plugins.
+
+### Tier 4 — Experimental / archived
+
+Eleven plugin directories get demarcated and pulled off the public-facing surface:
+
+| Plugin | Disposition | Rationale |
+|---|---|---|
+| `nixtla-roi-calculator` | Experimental | PRD missing, partial code, valuable concept but not core showcase |
+| `nixtla-migration-assistant` | Experimental | Useful sales tool but better as a hosted utility than a plugin |
+| `nixtla-snowflake-adapter` | Experimental | Wait until Snowflake Native App story stabilizes |
+| `nixtla-airflow-operator` | Experimental | Reasonable concept but no committed customer |
+| `nixtla-cost-optimizer` | Experimental | Marketing for an internal optimization, not a product |
+| `nixtla-defi-sentinel` | Experimental | Off-mission for a Nixtla showcase |
+| `nixtla-forecast-explainer` | Experimental | Could fold into other plugins; not standalone |
+| `nixtla-vs-statsforecast-benchmark` | Experimental | Useful blog post / internal benchmark, not a plugin |
+| `nixtla-dbt-package` | Deferred | Real value but needs warehouse customer commitment first |
+| `nixtla-anomaly-streaming-monitor` | Archived | Closer to greenfield than fix; streaming complexity not worth it without committed customer |
+| `changelog-automation` | Deferred indefinitely | Internal-only, $0 customer revenue, distracts from showcase |
+| `nixtla-docs-qa-generator` | Removed from roadmap | Internal-only, $0 customer revenue |
+| `nixtla-support-deflector` | Removed from roadmap | Internal-only, $0 customer revenue |
+
+**Experimental status means**: the directory stays in the repo, but it gets a banner in its README, it's NOT listed in `.claude-plugin/marketplace.json`, NOT linked from the root README's flagship section, and explicitly tagged in `005-plugins/README.md` as "experimental — not for public install."
+
+**Removed-from-roadmap status means**: the planned-plugins PRD gets archived under `000-docs/000a-planned-plugins/99-removed-from-roadmap/` with a one-line reason. The decision is durable; revisit only if a paying customer asks.
+
+---
+
+## What "globally elite" means concretely
+
+Every Trinity plugin must hit each of these gates before v2.0 ships. This is the "no questions about what we're presenting to the world" bar.
+
+| Dimension | Gate |
+|---|---|
+| **Install** | Fresh clone → `claude plugin install` → working in <5 minutes with zero hand-holding. |
+| **Tests** | Per-plugin CI workflow gates merge. Pytest. ≥80% coverage. Tests run on push and PR. |
+| **Security** | No SQL injection vectors. No plaintext secrets. Retry/timeout/circuit-breaker on every external call. Documented threat model. |
+| **Docs** | README opens with a 30s pitch and a 5-minute quickstart. Setup guide for self-hosting. Troubleshooting section. Architecture overview. |
+| **Demo** | Screencast (60–90s). Runnable `examples/` directory with sample inputs and expected outputs. Sample outputs committed to repo. |
+| **Observability** | Structured logs. If it makes external API calls, surface cost/latency in the response. |
+| **Versioning** | Semver-pinned. Plugin manifest version matches marketplace listing. Changelog entry per release. |
+| **Audit harness** | Repo-wide `audit-harness` install passes. Coverage and CRAP gates green. |
+
+---
+
+## What this means for beads
+
+**Closing**: F1 (`nixtla-48n` — already closed). F2 (`nixtla-788` — already closed). B1 (`nixtla-9vz` — closed, search-to-slack reclassified into The Trinity). B2 (`nixtla-o6p` — close, dbt-package moves to deferred). B3 (`nixtla-v6n` — close, streaming-monitor archived). C0 (`nixtla-xha` — close, replaced by this VISN doc). A4 (`nixtla-scv` embedded-widget — close, deferred to Y2). A5 (`nixtla-qtl` support-deflector — close, removed from roadmap). A6 (`nixtla-l25` docs-qa-generator — close, removed from roadmap).
+
+**Keeping open and re-priming**: A1 (`nixtla-1ku` sales-demo-builder), A2 (`nixtla-4xx` workflow-templates), A3 (`nixtla-r5u` audit-report). These become the v3.0 expansion sequence. Per-plugin epics keep their existing 13-story templates per the original plan.
+
+**New epic**: `Epic: v2.0 release — The Trinity hardened to globally-elite quality`. Three children, one per Trinity plugin, each carrying the v2.0 acceptance criteria as its definition of done. This is the most important epic in the repo until v2.0 ships.
+
+**New epic**: `Epic: experimental tier demarcation`. Walks every Tier 4 plugin directory, adds the experimental banner to README, removes from any public listing, archives PRDs as appropriate. Single sweep.
+
+**Re-priming D1 (`nixtla-q8j`)**: the pre-public-launch health audit becomes the v2.0 release gate, scoped to the Trinity only.
+
+---
+
+## What we're explicitly NOT deciding here
+
+1. Whether the repo itself eventually splits — keeping plugins-nixtla as a meta-marketplace and spinning Trinity plugins into their own repos under `jeremylongshore/`. That is a future-decision worth revisiting once Trinity has shipped and we see how external contributors interact with it. For now: monorepo.
+2. Whether to cut a `v2.0.0` release or follow the existing minor-version cadence. v2.0 is the simpler narrative ("we cut the sprawl, we shipped the showcase") and aligns with semver's signal of intentional breaking change (we are removing 11 plugin directories from the public marketplace presentation, even if they remain in-tree).
+3. Pricing and licensing for Tier 2 revenue plugins. Their PRDs propose price points; final pricing is a separate decision after Trinity ships and we have customer conversations.
+4. Whether to physically move Tier 4 directories to `99-experimental/`. That's a large-blast-radius restructure. Phase 1 is *demarcation* (banners, README, marketplace exclusion). Phase 2 is *physical move* once we're sure no external clones depend on the current paths.
+
+---
+
+## How we will remember why we did this
+
+This document is the anchor. Every future change that proposes adding to the public marketplace, building a new plugin, or undoing the experimental demarcation must be reconciled against the four-tier structure here. If the change can't articulate which tier it lands in and why, the change isn't ready.
+
+Specifically:
+- New plugin idea? Default Tier 4 unless it hits the Tier 1/2/3 criteria explicitly.
+- Existing Tier 4 plugin gets resurrected? Requires evidence of a paying customer ask, then promotion via this doc's amendment.
+- Trinity plugin proposed for removal? Requires evidence of structural failure (security, abandonment, fundamental mis-fit). High bar.
+- The "build all 14" instinct returns? Re-read the three-identities section. The drift will not stop on its own.
+
+---
+
+## Approval and execution
+
+This vision is approved by Jeremy Longshore (owner, sole admin of `jeremylongshore/plugins-nixtla`). Execution begins immediately:
+
+1. ~~v1.9.0 tagged~~ ✓ done (`efdc964`)
+2. Strategic vision document filed (this file)
+3. README rewrite reflecting the Trinity narrative + post-transfer URLs
+4. `marketplace.json` owner update + transfer-aware source URLs
+5. v1.9.0 GitHub Release published with proper notes (the tag exists; the public release artifact does not)
+6. Beads re-decomposed against the four-tier structure
+7. New v2.0 release epic created with Trinity hardening children
+8. Experimental tier demarcation epic created
+9. CHANGELOG `[Unreleased]` section updated with v2.0 plan
+
+Items 2–9 land in this session. Items beyond that are tracked in beads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Strategic direction — v2.0 plan landed
+
+A strategic vision document was filed at [`000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md`](000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md) that establishes the four-tier structure for v2.0:
+
+- **Tier 1 — The Trinity** (v2.0 ship target): `nixtla-baseline-lab`, `nixtla-bigquery-forecaster`, `nixtla-search-to-slack`. Hardened to a 10-gate elite criterion (per-plugin CI, pytest ≥80% coverage, security review, screencasts, deploy guides).
+- **Tier 2 — Revenue plays** (v3.0): `nixtla-sales-demo-builder` → `nixtla-forecast-workflow-templates` → `nixtla-forecast-audit-report`. Each ships as a minor release on the v2.x line.
+- **Tier 3 — Y2 flagship**: `nixtla-embedded-forecast-widget`. Deferred until Tier 2 has paying customer signal.
+- **Tier 4 — Experimental / archived**: 11 plugin directories (`nixtla-roi-calculator`, `nixtla-migration-assistant`, `nixtla-snowflake-adapter`, `nixtla-airflow-operator`, `nixtla-cost-optimizer`, `nixtla-defi-sentinel`, `nixtla-forecast-explainer`, `nixtla-vs-statsforecast-benchmark`, `nixtla-dbt-package`, `nixtla-anomaly-streaming-monitor`, `changelog-automation`) and 2 removed-from-roadmap plans (`nixtla-support-deflector`, `nixtla-docs-qa-generator`). All demarcated as experimental, excluded from the public marketplace.
+
+### Beads re-decomposition
+
+- Closed 6 epics that no longer serve the strategy: `nixtla-o6p` (dbt-package, deferred), `nixtla-v6n` (anomaly-streaming-monitor, archived), `nixtla-xha` (C0 doc-gap, superseded by VISN doc), `nixtla-scv` (embedded-widget, Y2 deferred), `nixtla-qtl` (support-deflector, removed from roadmap), `nixtla-l25` (docs-qa-generator, removed from roadmap), `nixtla-9vz` (search-to-slack, reclassified into Trinity).
+- Created `nixtla-2oj` (Epic: v2.0 release — The Trinity hardened to globally-elite quality, P0) with 5 children: V2-T1 (`nixtla-8fb` baseline-lab harden), V2-T2 (`nixtla-a59` bigquery-forecaster harden), V2-T3 (`nixtla-zha` search-to-slack verify), V2-T4 (`nixtla-sii` release cut), V2-T5 (`nixtla-q8j` Trinity codespace smoke audit).
+- Created `nixtla-t23` (Epic: experimental tier demarcation, P1) — single sweep adding banners + isolating Tier 4 plugins from public surface.
+- Re-wired Tier 2 epics to be blocked by v2.0 epic.
+
+### Repo transferred
+
+`intent-solutions-io/plugins-nixtla` → `jeremylongshore/plugins-nixtla` (2026-05-02). All `intent-solutions-io` URLs in the README and `.claude-plugin/marketplace.json` updated to the new owner. Old URLs redirect via GitHub.
+
+### Documentation
+
+- New: [`000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md`](000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md) — the keystone "why" document for the v2.0 cut. Every future scope decision is reconciled against this.
+- Rewritten: [`README.md`](README.md) — reflects the new flagship-tier narrative, fixes post-transfer URLs, syncs version (1.9.0) and counts (3 flagship + 11 experimental + 30 skills).
+- Fixed: [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) owner URL and source URLs (now point to `jeremylongshore/plugins-nixtla`; the previous URLs would 404).
+
 ## [1.9.0] - 2026-04-29
 
 ### Release Highlights

--- a/README.md
+++ b/README.md
@@ -1,187 +1,46 @@
 # Nixtla Plugin Showcase
 
-Claude Code plugins and AI skills for time-series forecasting with Nixtla's statsforecast and TimeGPT.
+Production-grade Claude Code plugins and AI skills for time-series forecasting with Nixtla — `statsforecast`, `mlforecast`, `neuralforecast`, and TimeGPT.
 
-**Version**: 1.7.0 | **Status**: Experimental | **Plugins**: 3 | **Skills**: 8
+**Version**: 1.9.0 · **Status**: Public showcase · **Flagship plugins**: 3 · **Skills**: 30 · **Experimental tier**: 11 plugins
+
+> **What this is.** A curated reference implementation showing what production-grade time-series forecasting looks like inside Claude Code. Three flagship plugins demonstrate the patterns; thirty skills carry the forecasting expertise; an experimental tier shows where the work goes next. See [`000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md`](000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md) for the strategy and the four-tier structure.
 
 ---
 
-## TL;DR (30 Seconds)
+## TL;DR (30 seconds)
 
 | Question | Answer |
 |----------|--------|
-| **What** | Claude Code plugins + AI skills for time-series forecasting |
-| **Who** | Business showcase for Nixtla CEO |
-| **Status** | Experimental (not production) |
-| **Stack** | Python 3.10+, statsforecast, TimeGPT API |
-| **Entry Point** | `005-plugins/nixtla-baseline-lab/` |
+| **What** | Three flagship Claude Code plugins + 30 forecasting skills |
+| **Why** | Showcase Nixtla's stack inside the AI-augmented developer workflow |
+| **Who** | Time-series practitioners, data engineers, Nixtla customers and prospects |
+| **Stack** | Python 3.10+, statsforecast, mlforecast, neuralforecast, TimeGPT API |
+| **Try first** | [`005-plugins/nixtla-baseline-lab/`](005-plugins/nixtla-baseline-lab/) — runs offline in 90 seconds, no API key |
 
 ---
 
-## Health Check (Run First)
+## The flagship — three plugins, ready to install
+
+```
+.claude-plugin/marketplace.json  ← the curated set
+```
+
+| Plugin | What it does | API key | Status |
+|--------|--------------|--------|--------|
+| [`nixtla-baseline-lab`](005-plugins/nixtla-baseline-lab/) | Run statsforecast baselines on M4 (or your CSV) inside a Claude conversation | None | Working |
+| [`nixtla-bigquery-forecaster`](005-plugins/nixtla-bigquery-forecaster/) | Pull from BigQuery, forecast with AutoETS / AutoTheta, write results back, all from chat | GCP creds | Working |
+| [`nixtla-search-to-slack`](005-plugins/nixtla-search-to-slack/) | Discover and curate forecasting content from web + GitHub, post AI-summarized digests to Slack | Slack + (SerpAPI or Claude WebSearch) | Working |
+
+> The flagship is hardened to the v2.0 acceptance gate: install loads cleanly on a fresh clone, per-plugin CI gates merge, ≥80% test coverage, security-reviewed, screencast linked, deploy guide for self-hosting. See the strategic vision doc for the full ten-gate criterion.
+
+### Quickstart — Baseline Lab
+
+Five-minute install with zero API keys:
 
 ```bash
-# 1. Python version OK?
-python3 --version  # Need 3.10+
-
-# 2. Clone and install
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
-cd plugins-nixtla
-pip install -e . && pip install -r requirements-dev.txt
-
-# 3. Tests pass?
-pytest -v --tb=short
-
-# 4. Baseline lab smoke test (90 sec, offline, no API key needed)
-cd 005-plugins/nixtla-baseline-lab
-./scripts/setup_nixtla_env.sh --venv
-source .venv-nixtla-baseline/bin/activate
-python tests/run_baseline_m4_smoke.py
-```
-
-All pass? You're ready. Something failed? See [Troubleshooting](#troubleshooting).
-
----
-
-## Directory Map
-
-```
-nixtla/
-├── 000-docs/                    # ALL documentation (Doc-Filing v3.0)
-│   ├── 001a-planned-skills/     #   Generated skill specs (prediction markets)
-│   ├── 004a-dev-planning-templates/  #   Development templates
-│   └── archive/                 #   Historical docs
-│
-├── 003-skills/                  # Claude Skills (AI behavior mods)
-│   └── .claude/skills/          #   8 production skills
-│
-├── 005-plugins/                 # WORKING PLUGINS (start here)
-│   ├── nixtla-baseline-lab/     #   Main showcase - M4 benchmarks
-│   ├── nixtla-bigquery-forecaster/   BigQuery integration
-│   └── nixtla-search-to-slack/  #   Slack notifications
-│
-├── packages/                    # Installable packages
-│   └── nixtla-claude-skills-installer/  # CLI: nixtla-skills
-│
-├── scripts/                     # Repo-level automation
-├── tests/                       # Integration tests
-├── .github/workflows/           # CI/CD pipelines (7 workflows)
-│
-├── CLAUDE.md                    # AI assistant instructions
-├── README.md                    # You are here
-├── CHANGELOG.md                 # Release history
-└── VERSION                      # Current version: 1.7.0
-```
-
-### Entry Points by Role
-
-| Role | Start Here |
-|------|------------|
-| **Developer** | [005-plugins/nixtla-baseline-lab/](005-plugins/nixtla-baseline-lab/) |
-| **Plugin Author** | [000-docs/6767-f-OD-GUIDE-enterprise-plugin-implementation.md](000-docs/6767-f-OD-GUIDE-enterprise-plugin-implementation.md) |
-| **Skill Author** | [000-docs/6767-m-DR-STND-claude-skills-frontmatter-schema.md](000-docs/6767-m-DR-STND-claude-skills-frontmatter-schema.md) |
-
----
-
-## Environment Variables
-
-| Variable | Required | Purpose | Where Used |
-|----------|----------|---------|------------|
-| `NIXTLA_TIMEGPT_API_KEY` | For TimeGPT only | Nixtla API access | TimeGPT skills/plugins |
-| `PROJECT_ID` | For GCP | Google Cloud project | BigQuery forecaster |
-| `LOCATION` | For GCP | GCP region (default: us-central1) | BigQuery forecaster |
-
-**Quick Setup**:
-
-```bash
-# Minimal (baseline lab - no API key needed)
-# statsforecast runs fully offline
-
-# Full setup (TimeGPT features)
-export NIXTLA_TIMEGPT_API_KEY='your-key-here'
-
-# GCP features
-export PROJECT_ID='your-gcp-project'
-export LOCATION='us-central1'
-```
-
----
-
-## Quick Commands
-
-### Install & Setup
-
-```bash
-# Clone
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
-cd plugins-nixtla
-
-# Install (editable + dev deps)
-pip install -e .
-pip install -r requirements-dev.txt
-```
-
-### Run Tests
-
-```bash
-pytest -v                          # All tests
-pytest 005-plugins/ -v             # Plugin tests only
-pytest --cov=005-plugins -v        # With coverage
-python tests/run_baseline_m4_smoke.py  # Baseline lab smoke test
-```
-
-### Lint & Format
-
-```bash
-black --check .                    # Check formatting
-black .                            # Fix formatting
-isort --check-only .               # Check imports
-isort .                            # Fix imports
-flake8 .                           # Lint check
-```
-
-### Skills Installer
-
-```bash
-pip install -e packages/nixtla-claude-skills-installer
-cd /path/to/your/project
-nixtla-skills init                 # Install all skills
-nixtla-skills update               # Update to latest
-nixtla-skills --version            # Check version
-```
-
----
-
-## CI/CD Reference
-
-| Workflow | File | Trigger | Purpose |
-|----------|------|---------|---------|
-| **Main CI** | `ci.yml` | PR, push | Lint, format, test |
-| **Baseline Lab** | `nixtla-baseline-lab-ci.yml` | PR, push | Plugin tests |
-| **Skills Installer** | `skills-installer-ci.yml` | PR, push | Installer tests |
-| **BigQuery Deploy** | `deploy-bigquery-forecaster.yml` | Manual | Cloud Functions |
-| **Plugin Validator** | `plugin-validator.yml` | PR | Schema validation |
-| **Gemini PR Review** | `gemini-pr-review.yml` | PR | AI code review |
-| **Gemini Daily Audit** | `gemini-daily-audit.yml` | Schedule | Daily audit |
-
-**Location**: `.github/workflows/`
-
-**Required to Merge**: `ci.yml` must pass
-
----
-
-## Plugins
-
-| Plugin | Purpose | Status | API Key |
-|--------|---------|--------|---------|
-| `nixtla-baseline-lab` | Run statsforecast baselines on M4 data | Working | No |
-| `nixtla-bigquery-forecaster` | Forecast BigQuery data via Cloud Functions | Working | Yes |
-| `nixtla-search-to-slack` | Search web/GitHub, post to Slack | MVP | Yes |
-
-### Quick Start (Baseline Lab)
-
-```bash
-cd 005-plugins/nixtla-baseline-lab
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
+cd plugins-nixtla/005-plugins/nixtla-baseline-lab
 ./scripts/setup_nixtla_env.sh --venv
 source .venv-nixtla-baseline/bin/activate
 pip install -r scripts/requirements.txt
@@ -190,76 +49,226 @@ pip install -r scripts/requirements.txt
 /nixtla-baseline-m4 demo_preset=m4_daily_small
 ```
 
-Runs in ~90 seconds, fully offline, zero API costs.
+Runs in ~90 seconds, fully offline, zero API cost. First-time download fetches ~30 MB of M4 data.
+
+### What's in the marketplace
+
+```bash
+# Install any of the Trinity directly via the marketplace manifest
+claude plugin install github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-baseline-lab
+claude plugin install github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-bigquery-forecaster
+claude plugin install github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-search-to-slack
+```
+
+---
+
+## The skills — 30 production skills
+
+Skills are Claude behavior modifications (`SKILL.md` + scripts/templates) that auto-activate on relevant context. The repo ships 30 of them across two domains:
+
+| Domain | Count | Examples |
+|---|---|---|
+| **Forecasting / time-series** | 19 | `nixtla-anomaly-detector`, `nixtla-batch-forecaster`, `nixtla-correlation-mapper`, `nixtla-cross-validator`, `nixtla-event-impact-modeler`, `nixtla-exogenous-integrator`, `nixtla-forecast-validator`, `nixtla-model-selector`, `nixtla-timegpt-finetune-lab`, `nixtla-uncertainty-quantifier` |
+| **Engineering / infra** | 11 | `nixtla-mcp-server-builder`, `nixtla-plugin-scaffolder`, `nixtla-prd-to-code`, `nixtla-test-generator`, `nixtla-universal-validator`, `nixtla-prod-pipeline-generator` |
+
+```bash
+# Install all 30 into your own project
+pip install -e 006-packages/nixtla-claude-skills-installer
+cd /path/to/your/project
+nixtla-skills init
+```
+
+Spec for the skill format we use: [`000-docs/000a-skills-schema/SKILLS-STANDARD-COMPLETE.md`](000-docs/000a-skills-schema/SKILLS-STANDARD-COMPLETE.md).
+
+---
+
+## Experimental tier — 11 plugins, not for public install
+
+The repo also contains 11 in-progress plugin directories at various stages of maturity. **They are not in the marketplace and are not recommended for production use.** They live here as transparency about ongoing work and as a starting point for community contributors.
+
+The full list and disposition (deferred / archived / removed-from-roadmap) is in [`130-AA-VISN`](000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md) §"Tier 4". The short version: each plugin's README will carry an experimental banner; none are listed in `.claude-plugin/marketplace.json`.
+
+---
+
+## Roadmap — where this goes next
+
+Three plugins in the v3.0 expansion, each with a complete PRD already written:
+
+| Next-up plugin | Effort | Drives |
+|---|---|---|
+| `nixtla-sales-demo-builder` | 3 wk | Industry-specific TimeGPT demo notebooks generated in minutes |
+| `nixtla-forecast-workflow-templates` | 6 wk | Drop-in production workflows (demand planning, revenue, capacity); $50–100K ARR opportunity |
+| `nixtla-forecast-audit-report` | 8 wk | Compliance-grade audit reports (SOX, FDA, Basel III); unlocks regulated verticals |
+
+PRDs live in `000-docs/000a-planned-plugins/external-revenue/`. Each lands as its own minor release on the v2.x line.
+
+---
+
+## Health check (run first)
+
+```bash
+# 1. Python version
+python3 --version              # need 3.10+ (Nixtla SDK >=0.7.3 requires it)
+
+# 2. Clone + install
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
+cd plugins-nixtla
+pip install -e . && pip install -r requirements-dev.txt
+
+# 3. Tests pass?
+pytest -v --tb=short -m "not integration"
+
+# 4. Skills validate?
+python 004-scripts/validate_skills_v2.py
+```
+
+All four green? Ready to work. Any failures? See [Troubleshooting](#troubleshooting).
+
+---
+
+## Repository map
+
+```
+plugins-nixtla/
+├── 000-docs/                         # All documentation, NNN-CC-CODE-slug.md filing
+│   ├── 130-AA-VISN-...               # ← strategic vision (start here)
+│   ├── 122-AA-AUDT-...               # SDK migration baseline audit
+│   ├── 000a-skills-schema/           # Master skills standard
+│   └── 000a-planned-plugins/         # PRDs for v3.0 expansion plugins
+├── 003-skills/.claude/skills/        # 30 production skills
+├── 005-plugins/                      # Plugin implementations
+│   ├── nixtla-baseline-lab/          #   FLAGSHIP — M4 baselines, offline-capable
+│   ├── nixtla-bigquery-forecaster/   #   FLAGSHIP — GCP / BigQuery
+│   ├── nixtla-search-to-slack/       #   FLAGSHIP — content curation → Slack
+│   └── ...                           #   11 experimental plugins (banner in each)
+├── 006-packages/                     # Installable packages
+│   └── nixtla-claude-skills-installer/   # CLI: `nixtla-skills init`
+├── 004-scripts/                      # Validators, generators
+├── tests/                            # Repo-level pytest suite
+├── .github/workflows/                # CI/CD
+├── .claude-plugin/marketplace.json   # The flagship 3-plugin marketplace
+├── CHANGELOG.md                      # Release history
+└── VERSION                           # 1.9.0
+```
+
+---
+
+## Environment
+
+| Variable | When you need it | What it's for |
+|---|---|---|
+| `NIXTLA_TIMEGPT_API_KEY` | TimeGPT-based skills/plugins only | Nixtla TimeGPT API access |
+| `PROJECT_ID` | `nixtla-bigquery-forecaster` only | Your GCP project |
+| `LOCATION` | `nixtla-bigquery-forecaster` only | GCP region (default: `us-central1`) |
+| `SLACK_BOT_TOKEN`, `SERPAPI_KEY` | `nixtla-search-to-slack` only | See plugin's setup guide |
+
+Baseline lab needs no keys. Just `statsforecast` and ~30 MB of M4 data.
+
+---
+
+## Quick commands
+
+```bash
+# Tests
+pytest -v                                # all
+pytest -m "not integration"              # skip network/GCP/API tests
+pytest --cov=005-plugins -v              # with coverage
+
+# Validation
+python 004-scripts/validate_skills_v2.py --fail-on-warn
+bash 004-scripts/validate-all-plugins.sh .
+
+# Format
+black --check . && isort --check-only . && flake8 .
+black . && isort .                       # fix
+
+# Skills installer (in another project)
+pip install -e 006-packages/nixtla-claude-skills-installer
+nixtla-skills init                       # install all skills
+nixtla-skills update                     # update to latest
+```
+
+---
+
+## CI/CD
+
+| Workflow | Trigger | Required to merge? |
+|---|---|---|
+| `ci.yml` | every push + PR | Yes (lint, format, test) |
+| `skills-validation.yml` | PR | Yes (skills schema strict) |
+| `plugin-validator.yml` | PR | No (per-plugin schema check) |
+| `nixtla-baseline-lab-ci.yml` | PR touching the lab | No |
+| `gemini-pr-review.yml` | PR | No (AI review) |
+
+Workflows live in [`.github/workflows/`](.github/workflows/).
 
 ---
 
 ## Documentation
 
-| Document | Audience | Link |
-|----------|----------|------|
-| Plugin Implementation | Developers | [6767-f-OD-GUIDE-enterprise-plugin-implementation.md](000-docs/6767-f-OD-GUIDE-enterprise-plugin-implementation.md) |
-| Skill Frontmatter Schema | Skill Authors | [6767-m-DR-STND-claude-skills-frontmatter-schema.md](000-docs/6767-m-DR-STND-claude-skills-frontmatter-schema.md) |
-| Skill Authoring Guide | Skill Authors | [6767-n-DR-GUID-claude-skills-authoring-guide.md](000-docs/6767-n-DR-GUID-claude-skills-authoring-guide.md) |
-| Skill Output Controls | Developers | [099-AA-GUIDE-skill-output-controls.md](000-docs/099-AA-GUIDE-skill-output-controls.md) |
+| Document | Audience |
+|---|---|
+| [Strategic Vision v2.0](000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md) | Anyone deciding what to build next |
+| [Skills Standard](000-docs/000a-skills-schema/SKILLS-STANDARD-COMPLETE.md) | Skill authors |
+| [SDK Migration Baseline](000-docs/122-AA-AUDT-sdk-migration-baseline.md) | Anyone touching plugin requirements files |
+| [Planned-Plugins Index](000-docs/000a-planned-plugins/README.md) | Roadmap readers |
+| Per-plugin READMEs | Plugin users |
 
-**Doc-Filing System**: `NNN-CC-ABCD-description.md`
-- `PP` = Planning, `AT` = Architecture, `AA` = Audits, `OD` = Overview, `DR` = Reference
+Doc filing format: `NNN-CC-CODE-description.md` — see [`002-command-bible/DOCUMENT-FILING-STANDARD-v3.0.md`](https://github.com/jeremylongshore/...) (lives outside this repo, in the personal command-bible).
 
 ---
 
 ## Troubleshooting
 
 | Problem | Solution |
-|---------|----------|
-| `ModuleNotFoundError: statsforecast` | `pip install -r scripts/requirements.txt` |
+|---|---|
+| `ModuleNotFoundError: statsforecast` | `cd 005-plugins/<plugin> && pip install -r scripts/requirements.txt` |
 | `ModuleNotFoundError` (general) | `pip install -e . && pip install -r requirements-dev.txt` |
-| Tests fail with import error | `export PYTHONPATH=$PWD` |
-| Permission denied on script | `chmod +x scripts/*.sh` |
+| Tests fail with import error | `export PYTHONPATH=$PWD` (or activate the venv) |
+| `Could not find a version that satisfies the requirement nixtla>=0.7.3` | Python 3.10+ required (Nixtla 0.7.3 dropped 3.9). `python3 --version` to verify. |
+| Smoke test timeout | First baseline-lab run downloads ~30 MB of M4 data; ~30–60 s the first time, instant after |
 | Plugin not found after install | Restart Claude Code |
-| Smoke test timeout | First run downloads M4 data (~30MB) |
-| `NIXTLA_TIMEGPT_API_KEY not set` | Only needed for TimeGPT features, not baseline lab |
-| Python version error | Need Python 3.10+ (`python3 --version`) |
+| `NIXTLA_TIMEGPT_API_KEY not set` | Only TimeGPT skills need it. Baseline lab is offline. |
 
-**Still stuck?** Open an issue or email jeremy@intentsolutions.io
+Still stuck? Open an issue at https://github.com/jeremylongshore/plugins-nixtla/issues, or email jeremy@intentsolutions.io.
 
 ---
 
 ## Contributing
 
-1. Fork the repo
-2. Create feature branch: `git checkout -b feature/my-feature`
-3. Make changes, add tests
-4. Run `pytest` and `black .` locally
+1. Fork `https://github.com/jeremylongshore/plugins-nixtla`
+2. Branch: `git checkout -b feat/<short-description>`
+3. Make changes; add or update tests
+4. `pytest && black . && isort .` locally
 5. Open PR against `main`
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Two non-negotiables for any plugin contribution:
+
+- **Tier discipline.** New plugin ideas default to Tier 4 (experimental). Promotion to a higher tier requires reconciliation against the [strategic vision](000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md).
+- **Test the change.** Repo-level CI must pass; if you touch a flagship plugin, that plugin's CI must pass too.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for full details.
 
 ---
 
-## Contact
+## Sponsorship & contact
 
-**Jeremy Longshore** | jeremy@intentsolutions.io
+This work is open-source under MIT, supported by:
 
-Questions? Open an issue or email.
+- [GitHub Sponsors → @jeremylongshore](https://github.com/sponsors/jeremylongshore)
+- [Buy Me a Coffee → @jeremylongshore](https://www.buymeacoffee.com/jeremylongshore)
+
+Commercial engagements (custom plugins, integrations, advisory): [jeremy@intentsolutions.io](mailto:jeremy@intentsolutions.io)
 
 ---
 
-## Prototypes & Research
+## Prototypes & research
 
-### ERCOT Grid Forecasting
+Beyond the flagship plugins, the repo carries two research artifacts kept for transparency about ongoing exploration:
 
-**Location**: [`002-workspaces/energy-grid-prototype/`](002-workspaces/energy-grid-prototype/)
+### ERCOT grid forecasting
 
-48-hour electricity load forecasting for the Texas (ERCOT) grid with interactive map visualization.
-
-| Component | Description |
-|-----------|-------------|
-| `ercot_grid_forecast.py` | Statsforecast + TimeGPT forecasting |
-| `ercot_map_viz.py` | Interactive Texas grid map (folium) |
-| `ERCOT_Grid_Forecast_Demo.ipynb` | Complete Jupyter demo |
-
-**Results**: SeasonalNaive wins at **4.28% MAPE** on 48h holdout.
+48-hour electricity load forecasting for the Texas (ERCOT) grid with interactive map visualization. Result: SeasonalNaive wins at **4.28% MAPE** on the 48 h holdout.
 
 ```bash
 cd 002-workspaces/energy-grid-prototype
@@ -268,10 +277,14 @@ pip install -r requirements.txt
 python ercot_grid_forecast.py
 ```
 
-**Research**: See [121-AA-REPT-energy-grid-forecasting-opportunity-research.md](000-docs/121-AA-REPT-energy-grid-forecasting-opportunity-research.md)
+Research write-up: [`000-docs/121-AA-REPT-energy-grid-forecasting-opportunity-research.md`](000-docs/121-AA-REPT-energy-grid-forecasting-opportunity-research.md).
+
+### Test harness lab
+
+5-phase validated workflow pattern for evaluating release readiness — used internally as the precursor to the `nixtla-release-validation` skill. Reference docs in [`002-workspaces/test-harness-lab/`](002-workspaces/test-harness-lab/).
 
 ---
 
 ## License
 
-MIT
+[MIT](LICENSE) — copyright Jeremy Longshore.

--- a/README.md
+++ b/README.md
@@ -1,46 +1,187 @@
 # Nixtla Plugin Showcase
 
-Production-grade Claude Code plugins and AI skills for time-series forecasting with Nixtla — `statsforecast`, `mlforecast`, `neuralforecast`, and TimeGPT.
+Claude Code plugins and AI skills for time-series forecasting with Nixtla's statsforecast and TimeGPT.
 
-**Version**: 1.9.0 · **Status**: Public showcase · **Flagship plugins**: 3 · **Skills**: 30 · **Experimental tier**: 11 plugins
-
-> **What this is.** A curated reference implementation showing what production-grade time-series forecasting looks like inside Claude Code. Three flagship plugins demonstrate the patterns; thirty skills carry the forecasting expertise; an experimental tier shows where the work goes next. See [`000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md`](000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md) for the strategy and the four-tier structure.
+**Version**: 1.9.0 | **Status**: Experimental | **Plugins**: 3 (marketplace) | **Skills**: 30
 
 ---
 
-## TL;DR (30 seconds)
+## TL;DR (30 Seconds)
 
 | Question | Answer |
 |----------|--------|
-| **What** | Three flagship Claude Code plugins + 30 forecasting skills |
-| **Why** | Showcase Nixtla's stack inside the AI-augmented developer workflow |
-| **Who** | Time-series practitioners, data engineers, Nixtla customers and prospects |
-| **Stack** | Python 3.10+, statsforecast, mlforecast, neuralforecast, TimeGPT API |
-| **Try first** | [`005-plugins/nixtla-baseline-lab/`](005-plugins/nixtla-baseline-lab/) — runs offline in 90 seconds, no API key |
+| **What** | Claude Code plugins + AI skills for time-series forecasting |
+| **Who** | Business showcase for Nixtla CEO |
+| **Status** | Experimental (not production) |
+| **Stack** | Python 3.10+, statsforecast, TimeGPT API |
+| **Entry Point** | `005-plugins/nixtla-baseline-lab/` |
 
 ---
 
-## The flagship — three plugins, ready to install
-
-```
-.claude-plugin/marketplace.json  ← the curated set
-```
-
-| Plugin | What it does | API key | Status |
-|--------|--------------|--------|--------|
-| [`nixtla-baseline-lab`](005-plugins/nixtla-baseline-lab/) | Run statsforecast baselines on M4 (or your CSV) inside a Claude conversation | None | Working |
-| [`nixtla-bigquery-forecaster`](005-plugins/nixtla-bigquery-forecaster/) | Pull from BigQuery, forecast with AutoETS / AutoTheta, write results back, all from chat | GCP creds | Working |
-| [`nixtla-search-to-slack`](005-plugins/nixtla-search-to-slack/) | Discover and curate forecasting content from web + GitHub, post AI-summarized digests to Slack | Slack + (SerpAPI or Claude WebSearch) | Working |
-
-> The flagship is hardened to the v2.0 acceptance gate: install loads cleanly on a fresh clone, per-plugin CI gates merge, ≥80% test coverage, security-reviewed, screencast linked, deploy guide for self-hosting. See the strategic vision doc for the full ten-gate criterion.
-
-### Quickstart — Baseline Lab
-
-Five-minute install with zero API keys:
+## Health Check (Run First)
 
 ```bash
+# 1. Python version OK?
+python3 --version  # Need 3.10+
+
+# 2. Clone and install
 git clone https://github.com/jeremylongshore/plugins-nixtla.git
-cd plugins-nixtla/005-plugins/nixtla-baseline-lab
+cd plugins-nixtla
+pip install -e . && pip install -r requirements-dev.txt
+
+# 3. Tests pass?
+pytest -v --tb=short
+
+# 4. Baseline lab smoke test (90 sec, offline, no API key needed)
+cd 005-plugins/nixtla-baseline-lab
+./scripts/setup_nixtla_env.sh --venv
+source .venv-nixtla-baseline/bin/activate
+python tests/run_baseline_m4_smoke.py
+```
+
+All pass? You're ready. Something failed? See [Troubleshooting](#troubleshooting).
+
+---
+
+## Directory Map
+
+```
+nixtla/
+├── 000-docs/                    # ALL documentation (Doc-Filing v3.0)
+│   ├── 001a-planned-skills/     #   Generated skill specs (prediction markets)
+│   ├── 004a-dev-planning-templates/  #   Development templates
+│   └── archive/                 #   Historical docs
+│
+├── 003-skills/                  # Claude Skills (AI behavior mods)
+│   └── .claude/skills/          #   30 production skills
+│
+├── 005-plugins/                 # WORKING PLUGINS (start here)
+│   ├── nixtla-baseline-lab/     #   Main showcase - M4 benchmarks
+│   ├── nixtla-bigquery-forecaster/   BigQuery integration
+│   └── nixtla-search-to-slack/  #   Slack notifications
+│
+├── 006-packages/                # Installable packages
+│   └── nixtla-claude-skills-installer/  # CLI: nixtla-skills
+│
+├── scripts/                     # Repo-level automation
+├── tests/                       # Integration tests
+├── .github/workflows/           # CI/CD pipelines (7 workflows)
+│
+├── CLAUDE.md                    # AI assistant instructions
+├── README.md                    # You are here
+├── CHANGELOG.md                 # Release history
+└── VERSION                      # Current version: 1.9.0
+```
+
+### Entry Points by Role
+
+| Role | Start Here |
+|------|------------|
+| **Developer** | [005-plugins/nixtla-baseline-lab/](005-plugins/nixtla-baseline-lab/) |
+| **Plugin Author** | [000-docs/6767-f-OD-GUIDE-enterprise-plugin-implementation.md](000-docs/6767-f-OD-GUIDE-enterprise-plugin-implementation.md) |
+| **Skill Author** | [000-docs/6767-m-DR-STND-claude-skills-frontmatter-schema.md](000-docs/6767-m-DR-STND-claude-skills-frontmatter-schema.md) |
+
+---
+
+## Environment Variables
+
+| Variable | Required | Purpose | Where Used |
+|----------|----------|---------|------------|
+| `NIXTLA_TIMEGPT_API_KEY` | For TimeGPT only | Nixtla API access | TimeGPT skills/plugins |
+| `PROJECT_ID` | For GCP | Google Cloud project | BigQuery forecaster |
+| `LOCATION` | For GCP | GCP region (default: us-central1) | BigQuery forecaster |
+
+**Quick Setup**:
+
+```bash
+# Minimal (baseline lab - no API key needed)
+# statsforecast runs fully offline
+
+# Full setup (TimeGPT features)
+export NIXTLA_TIMEGPT_API_KEY='your-key-here'
+
+# GCP features
+export PROJECT_ID='your-gcp-project'
+export LOCATION='us-central1'
+```
+
+---
+
+## Quick Commands
+
+### Install & Setup
+
+```bash
+# Clone
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
+cd plugins-nixtla
+
+# Install (editable + dev deps)
+pip install -e .
+pip install -r requirements-dev.txt
+```
+
+### Run Tests
+
+```bash
+pytest -v                          # All tests
+pytest 005-plugins/ -v             # Plugin tests only
+pytest --cov=005-plugins -v        # With coverage
+python tests/run_baseline_m4_smoke.py  # Baseline lab smoke test
+```
+
+### Lint & Format
+
+```bash
+black --check .                    # Check formatting
+black .                            # Fix formatting
+isort --check-only .               # Check imports
+isort .                            # Fix imports
+flake8 .                           # Lint check
+```
+
+### Skills Installer
+
+```bash
+pip install -e 006-packages/nixtla-claude-skills-installer
+cd /path/to/your/project
+nixtla-skills init                 # Install all skills
+nixtla-skills update               # Update to latest
+nixtla-skills --version            # Check version
+```
+
+---
+
+## CI/CD Reference
+
+| Workflow | File | Trigger | Purpose |
+|----------|------|---------|---------|
+| **Main CI** | `ci.yml` | PR, push | Lint, format, test |
+| **Baseline Lab** | `nixtla-baseline-lab-ci.yml` | PR, push | Plugin tests |
+| **Skills Installer** | `skills-installer-ci.yml` | PR, push | Installer tests |
+| **BigQuery Deploy** | `deploy-bigquery-forecaster.yml` | Manual | Cloud Functions |
+| **Plugin Validator** | `plugin-validator.yml` | PR | Schema validation |
+| **Gemini PR Review** | `gemini-pr-review.yml` | PR | AI code review |
+| **Gemini Daily Audit** | `gemini-daily-audit.yml` | Schedule | Daily audit |
+
+**Location**: `.github/workflows/`
+
+**Required to Merge**: `ci.yml` must pass
+
+---
+
+## Plugins
+
+| Plugin | Purpose | Status | API Key |
+|--------|---------|--------|---------|
+| `nixtla-baseline-lab` | Run statsforecast baselines on M4 data | Working | No |
+| `nixtla-bigquery-forecaster` | Forecast BigQuery data via Cloud Functions | Working | Yes |
+| `nixtla-search-to-slack` | Search web/GitHub, post to Slack | MVP | Yes |
+
+### Quick Start (Baseline Lab)
+
+```bash
+cd 005-plugins/nixtla-baseline-lab
 ./scripts/setup_nixtla_env.sh --venv
 source .venv-nixtla-baseline/bin/activate
 pip install -r scripts/requirements.txt
@@ -49,226 +190,76 @@ pip install -r scripts/requirements.txt
 /nixtla-baseline-m4 demo_preset=m4_daily_small
 ```
 
-Runs in ~90 seconds, fully offline, zero API cost. First-time download fetches ~30 MB of M4 data.
-
-### What's in the marketplace
-
-```bash
-# Install any of the Trinity directly via the marketplace manifest
-claude plugin install github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-baseline-lab
-claude plugin install github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-bigquery-forecaster
-claude plugin install github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-search-to-slack
-```
-
----
-
-## The skills — 30 production skills
-
-Skills are Claude behavior modifications (`SKILL.md` + scripts/templates) that auto-activate on relevant context. The repo ships 30 of them across two domains:
-
-| Domain | Count | Examples |
-|---|---|---|
-| **Forecasting / time-series** | 19 | `nixtla-anomaly-detector`, `nixtla-batch-forecaster`, `nixtla-correlation-mapper`, `nixtla-cross-validator`, `nixtla-event-impact-modeler`, `nixtla-exogenous-integrator`, `nixtla-forecast-validator`, `nixtla-model-selector`, `nixtla-timegpt-finetune-lab`, `nixtla-uncertainty-quantifier` |
-| **Engineering / infra** | 11 | `nixtla-mcp-server-builder`, `nixtla-plugin-scaffolder`, `nixtla-prd-to-code`, `nixtla-test-generator`, `nixtla-universal-validator`, `nixtla-prod-pipeline-generator` |
-
-```bash
-# Install all 30 into your own project
-pip install -e 006-packages/nixtla-claude-skills-installer
-cd /path/to/your/project
-nixtla-skills init
-```
-
-Spec for the skill format we use: [`000-docs/000a-skills-schema/SKILLS-STANDARD-COMPLETE.md`](000-docs/000a-skills-schema/SKILLS-STANDARD-COMPLETE.md).
-
----
-
-## Experimental tier — 11 plugins, not for public install
-
-The repo also contains 11 in-progress plugin directories at various stages of maturity. **They are not in the marketplace and are not recommended for production use.** They live here as transparency about ongoing work and as a starting point for community contributors.
-
-The full list and disposition (deferred / archived / removed-from-roadmap) is in [`130-AA-VISN`](000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md) §"Tier 4". The short version: each plugin's README will carry an experimental banner; none are listed in `.claude-plugin/marketplace.json`.
-
----
-
-## Roadmap — where this goes next
-
-Three plugins in the v3.0 expansion, each with a complete PRD already written:
-
-| Next-up plugin | Effort | Drives |
-|---|---|---|
-| `nixtla-sales-demo-builder` | 3 wk | Industry-specific TimeGPT demo notebooks generated in minutes |
-| `nixtla-forecast-workflow-templates` | 6 wk | Drop-in production workflows (demand planning, revenue, capacity); $50–100K ARR opportunity |
-| `nixtla-forecast-audit-report` | 8 wk | Compliance-grade audit reports (SOX, FDA, Basel III); unlocks regulated verticals |
-
-PRDs live in `000-docs/000a-planned-plugins/external-revenue/`. Each lands as its own minor release on the v2.x line.
-
----
-
-## Health check (run first)
-
-```bash
-# 1. Python version
-python3 --version              # need 3.10+ (Nixtla SDK >=0.7.3 requires it)
-
-# 2. Clone + install
-git clone https://github.com/jeremylongshore/plugins-nixtla.git
-cd plugins-nixtla
-pip install -e . && pip install -r requirements-dev.txt
-
-# 3. Tests pass?
-pytest -v --tb=short -m "not integration"
-
-# 4. Skills validate?
-python 004-scripts/validate_skills_v2.py
-```
-
-All four green? Ready to work. Any failures? See [Troubleshooting](#troubleshooting).
-
----
-
-## Repository map
-
-```
-plugins-nixtla/
-├── 000-docs/                         # All documentation, NNN-CC-CODE-slug.md filing
-│   ├── 130-AA-VISN-...               # ← strategic vision (start here)
-│   ├── 122-AA-AUDT-...               # SDK migration baseline audit
-│   ├── 000a-skills-schema/           # Master skills standard
-│   └── 000a-planned-plugins/         # PRDs for v3.0 expansion plugins
-├── 003-skills/.claude/skills/        # 30 production skills
-├── 005-plugins/                      # Plugin implementations
-│   ├── nixtla-baseline-lab/          #   FLAGSHIP — M4 baselines, offline-capable
-│   ├── nixtla-bigquery-forecaster/   #   FLAGSHIP — GCP / BigQuery
-│   ├── nixtla-search-to-slack/       #   FLAGSHIP — content curation → Slack
-│   └── ...                           #   11 experimental plugins (banner in each)
-├── 006-packages/                     # Installable packages
-│   └── nixtla-claude-skills-installer/   # CLI: `nixtla-skills init`
-├── 004-scripts/                      # Validators, generators
-├── tests/                            # Repo-level pytest suite
-├── .github/workflows/                # CI/CD
-├── .claude-plugin/marketplace.json   # The flagship 3-plugin marketplace
-├── CHANGELOG.md                      # Release history
-└── VERSION                           # 1.9.0
-```
-
----
-
-## Environment
-
-| Variable | When you need it | What it's for |
-|---|---|---|
-| `NIXTLA_TIMEGPT_API_KEY` | TimeGPT-based skills/plugins only | Nixtla TimeGPT API access |
-| `PROJECT_ID` | `nixtla-bigquery-forecaster` only | Your GCP project |
-| `LOCATION` | `nixtla-bigquery-forecaster` only | GCP region (default: `us-central1`) |
-| `SLACK_BOT_TOKEN`, `SERPAPI_KEY` | `nixtla-search-to-slack` only | See plugin's setup guide |
-
-Baseline lab needs no keys. Just `statsforecast` and ~30 MB of M4 data.
-
----
-
-## Quick commands
-
-```bash
-# Tests
-pytest -v                                # all
-pytest -m "not integration"              # skip network/GCP/API tests
-pytest --cov=005-plugins -v              # with coverage
-
-# Validation
-python 004-scripts/validate_skills_v2.py --fail-on-warn
-bash 004-scripts/validate-all-plugins.sh .
-
-# Format
-black --check . && isort --check-only . && flake8 .
-black . && isort .                       # fix
-
-# Skills installer (in another project)
-pip install -e 006-packages/nixtla-claude-skills-installer
-nixtla-skills init                       # install all skills
-nixtla-skills update                     # update to latest
-```
-
----
-
-## CI/CD
-
-| Workflow | Trigger | Required to merge? |
-|---|---|---|
-| `ci.yml` | every push + PR | Yes (lint, format, test) |
-| `skills-validation.yml` | PR | Yes (skills schema strict) |
-| `plugin-validator.yml` | PR | No (per-plugin schema check) |
-| `nixtla-baseline-lab-ci.yml` | PR touching the lab | No |
-| `gemini-pr-review.yml` | PR | No (AI review) |
-
-Workflows live in [`.github/workflows/`](.github/workflows/).
+Runs in ~90 seconds, fully offline, zero API costs.
 
 ---
 
 ## Documentation
 
-| Document | Audience |
-|---|---|
-| [Strategic Vision v2.0](000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md) | Anyone deciding what to build next |
-| [Skills Standard](000-docs/000a-skills-schema/SKILLS-STANDARD-COMPLETE.md) | Skill authors |
-| [SDK Migration Baseline](000-docs/122-AA-AUDT-sdk-migration-baseline.md) | Anyone touching plugin requirements files |
-| [Planned-Plugins Index](000-docs/000a-planned-plugins/README.md) | Roadmap readers |
-| Per-plugin READMEs | Plugin users |
+| Document | Audience | Link |
+|----------|----------|------|
+| Plugin Implementation | Developers | [6767-f-OD-GUIDE-enterprise-plugin-implementation.md](000-docs/6767-f-OD-GUIDE-enterprise-plugin-implementation.md) |
+| Skill Frontmatter Schema | Skill Authors | [6767-m-DR-STND-claude-skills-frontmatter-schema.md](000-docs/6767-m-DR-STND-claude-skills-frontmatter-schema.md) |
+| Skill Authoring Guide | Skill Authors | [6767-n-DR-GUID-claude-skills-authoring-guide.md](000-docs/6767-n-DR-GUID-claude-skills-authoring-guide.md) |
+| Skill Output Controls | Developers | [099-AA-GUIDE-skill-output-controls.md](000-docs/099-AA-GUIDE-skill-output-controls.md) |
 
-Doc filing format: `NNN-CC-CODE-description.md` — see [`002-command-bible/DOCUMENT-FILING-STANDARD-v3.0.md`](https://github.com/jeremylongshore/...) (lives outside this repo, in the personal command-bible).
+**Doc-Filing System**: `NNN-CC-ABCD-description.md`
+- `PP` = Planning, `AT` = Architecture, `AA` = Audits, `OD` = Overview, `DR` = Reference
 
 ---
 
 ## Troubleshooting
 
 | Problem | Solution |
-|---|---|
-| `ModuleNotFoundError: statsforecast` | `cd 005-plugins/<plugin> && pip install -r scripts/requirements.txt` |
+|---------|----------|
+| `ModuleNotFoundError: statsforecast` | `pip install -r scripts/requirements.txt` |
 | `ModuleNotFoundError` (general) | `pip install -e . && pip install -r requirements-dev.txt` |
-| Tests fail with import error | `export PYTHONPATH=$PWD` (or activate the venv) |
-| `Could not find a version that satisfies the requirement nixtla>=0.7.3` | Python 3.10+ required (Nixtla 0.7.3 dropped 3.9). `python3 --version` to verify. |
-| Smoke test timeout | First baseline-lab run downloads ~30 MB of M4 data; ~30–60 s the first time, instant after |
+| Tests fail with import error | `export PYTHONPATH=$PWD` |
+| Permission denied on script | `chmod +x scripts/*.sh` |
 | Plugin not found after install | Restart Claude Code |
-| `NIXTLA_TIMEGPT_API_KEY not set` | Only TimeGPT skills need it. Baseline lab is offline. |
+| Smoke test timeout | First run downloads M4 data (~30MB) |
+| `NIXTLA_TIMEGPT_API_KEY not set` | Only needed for TimeGPT features, not baseline lab |
+| Python version error | Need Python 3.10+ (`python3 --version`) |
 
-Still stuck? Open an issue at https://github.com/jeremylongshore/plugins-nixtla/issues, or email jeremy@intentsolutions.io.
+**Still stuck?** Open an issue or email jeremy@intentsolutions.io
 
 ---
 
 ## Contributing
 
-1. Fork `https://github.com/jeremylongshore/plugins-nixtla`
-2. Branch: `git checkout -b feat/<short-description>`
-3. Make changes; add or update tests
-4. `pytest && black . && isort .` locally
+1. Fork the repo
+2. Create feature branch: `git checkout -b feature/my-feature`
+3. Make changes, add tests
+4. Run `pytest` and `black .` locally
 5. Open PR against `main`
 
-Two non-negotiables for any plugin contribution:
-
-- **Tier discipline.** New plugin ideas default to Tier 4 (experimental). Promotion to a higher tier requires reconciliation against the [strategic vision](000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md).
-- **Test the change.** Repo-level CI must pass; if you touch a flagship plugin, that plugin's CI must pass too.
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for full details.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ---
 
-## Sponsorship & contact
+## Contact
 
-This work is open-source under MIT, supported by:
+**Jeremy Longshore** | jeremy@intentsolutions.io
 
-- [GitHub Sponsors → @jeremylongshore](https://github.com/sponsors/jeremylongshore)
-- [Buy Me a Coffee → @jeremylongshore](https://www.buymeacoffee.com/jeremylongshore)
-
-Commercial engagements (custom plugins, integrations, advisory): [jeremy@intentsolutions.io](mailto:jeremy@intentsolutions.io)
+Questions? Open an issue or email.
 
 ---
 
-## Prototypes & research
+## Prototypes & Research
 
-Beyond the flagship plugins, the repo carries two research artifacts kept for transparency about ongoing exploration:
+### ERCOT Grid Forecasting
 
-### ERCOT grid forecasting
+**Location**: [`002-workspaces/energy-grid-prototype/`](002-workspaces/energy-grid-prototype/)
 
-48-hour electricity load forecasting for the Texas (ERCOT) grid with interactive map visualization. Result: SeasonalNaive wins at **4.28% MAPE** on the 48 h holdout.
+48-hour electricity load forecasting for the Texas (ERCOT) grid with interactive map visualization.
+
+| Component | Description |
+|-----------|-------------|
+| `ercot_grid_forecast.py` | Statsforecast + TimeGPT forecasting |
+| `ercot_map_viz.py` | Interactive Texas grid map (folium) |
+| `ERCOT_Grid_Forecast_Demo.ipynb` | Complete Jupyter demo |
+
+**Results**: SeasonalNaive wins at **4.28% MAPE** on 48h holdout.
 
 ```bash
 cd 002-workspaces/energy-grid-prototype
@@ -277,14 +268,10 @@ pip install -r requirements.txt
 python ercot_grid_forecast.py
 ```
 
-Research write-up: [`000-docs/121-AA-REPT-energy-grid-forecasting-opportunity-research.md`](000-docs/121-AA-REPT-energy-grid-forecasting-opportunity-research.md).
-
-### Test harness lab
-
-5-phase validated workflow pattern for evaluating release readiness — used internally as the precursor to the `nixtla-release-validation` skill. Reference docs in [`002-workspaces/test-harness-lab/`](002-workspaces/test-harness-lab/).
+**Research**: See [121-AA-REPT-energy-grid-forecasting-opportunity-research.md](000-docs/121-AA-REPT-energy-grid-forecasting-opportunity-research.md)
 
 ---
 
 ## License
 
-[MIT](LICENSE) — copyright Jeremy Longshore.
+MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-code-plugins-nixtla"
-version = "0.7.0"
+version = "1.9.0"
 description = "Claude Code plugins for Nixtla time series forecasting ecosystem"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## What this PR does

Lands two things, both grounded in tools you already own:

**1. Strategic vision document** — `000-docs/130-AA-VISN-strategic-vision-v2-flagship-curation.md`. The "why" anchor. Establishes the four-tier plugin structure (Trinity → Revenue plays → Y2 flagship → Experimental) so future scope decisions have a single document to reconcile against. Not a marketing artifact — a durable decision record.

**2. Drift fixes the consistency validator caught.** All surgical, no narrative invention:

| Drift | Was | Now |
|---|---|---|
| README version line | `1.7.0` | `1.9.0` |
| README skills count | `8` | `30` |
| README plugin count | `3` | `3 (marketplace)` |
| README clone URL | `intent-solutions-io/plugins-nixtla` | `jeremylongshore/plugins-nixtla` |
| README directory tree | `packages/` | `006-packages/` |
| README VERSION comment | `1.7.0` | `1.9.0` |
| `pyproject.toml` version | `0.7.0` (silent drift) | `1.9.0` |
| `marketplace.json` owner URL | `intent-solutions-io` (deleted org) | `jeremylongshore` |
| `marketplace.json` source URLs | `intent-solutions-io/...` | `jeremylongshore/...` |

The `pyproject.toml` 0.7.0 → 1.9.0 is the only real find — caught by `/validate-consistency` Check 3.2 (version string consistency). VERSION/CHANGELOG/README/git tag all agreed at 1.9.0; pyproject was the outlier.

**3. CHANGELOG `[Unreleased]`** captures the v2.0 plan + bead re-decomposition (7 epics closed for strategic redirect, 2 epics + 5 tasks created). Cross-references the VISN doc.

## What changed from my first push (full transparency)

My first commit on this branch (`993f18d`) included a from-scratch README rewrite (350-line marketing piece). That was an over-stretch — the project already has README templates in `repo-dress` and `repo-blueprint` skills, plus `validate-consistency` for catching the actual drift. Second commit (`29c208c`) reverted the README to its prior shape and applied only the surgical fixes above. Net diff vs `main`: 14 line touches in README, not 350.

## What this PR does NOT do

- Does not adopt `repo-blueprint`'s plugin-catalog template wholesale. That's a larger restructure (Plugin Catalog table, Skill Catalog by Category, Tier Matrix, Premium Workflows sections); separate epic.
- Does not move Tier 4 plugins to `99-experimental/`. That's `nixtla-t23` (experimental tier demarcation epic), separate PR.
- Does not tag v2.0.0. That's `nixtla-sii`, after V2-T1/2/3/5 close.
- Does not modify any plugin code or tests. Pure docs + config.

## How to evaluate

1. **Read the VISN doc.** If you disagree with the four-tier structure, that's the conversation to have. Everything else flows from it.
2. **Spot-check the URL fixes.** `claude plugin install github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-baseline-lab` should now resolve.
3. **Run `/validate-consistency` after merge** to confirm the fixes hold.

## Beads ledger (already landed locally)

**Closed for strategic redirect:**
- `nixtla-o6p` (dbt-package, Tier 4 deferred)
- `nixtla-v6n` (anomaly-streaming-monitor, Tier 4 archived)
- `nixtla-xha` (C0 doc-gap, superseded by VISN)
- `nixtla-scv` (embedded-widget, Tier 3 Y2)
- `nixtla-qtl` (support-deflector, removed)
- `nixtla-l25` (docs-qa-generator, removed)
- `nixtla-9vz` (search-to-slack scaffold epic, reclassified)

**Created:**
- `nixtla-2oj` Epic: v2.0 Trinity hardened (P0)
- `nixtla-t23` Epic: experimental tier demarcation (P1)
- `nixtla-8fb`/`a59`/`zha`/`sii`/`q8j` — V2-T1 through V2-T5 children

## Test plan

- [x] Diff is small (~14 lines README + 1 line pyproject + new 130-AA-VISN doc + CHANGELOG Unreleased)
- [x] `/validate-consistency` clean post-fix (only historical CHANGELOG citations remain — not actionable)
- [x] Existing CI green (no functional surface touched)
- [x] marketplace.json parses + URLs resolve