### PR TITLE
feat(airflow-operator): ship v1.0 — real Airflow tooling (Epic 1.6)

### DIFF
--- a/.github/workflows/nixtla-airflow-operator-ci.yml
+++ b/.github/workflows/nixtla-airflow-operator-ci.yml
@@ -1,0 +1,95 @@
+name: Nixtla Airflow Operator CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '005-plugins/nixtla-airflow-operator/**'
+      - '.github/workflows/nixtla-airflow-operator-ci.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '005-plugins/nixtla-airflow-operator/**'
+      - '.github/workflows/nixtla-airflow-operator-ci.yml'
+
+jobs:
+  test:
+    name: Test + Coverage
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 005-plugins/nixtla-airflow-operator
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: '005-plugins/nixtla-airflow-operator/scripts/requirements.txt'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements.txt
+          pip install pytest pytest-cov
+
+      - name: Import sanity check
+        run: |
+          python -c "import sys; sys.path.insert(0, 'scripts'); import airflow_mcp; print('IMPORTS OK')"
+
+      - name: Run pytest with coverage
+        run: |
+          PYTHONPATH=scripts pytest tests/ \
+            --cov=airflow_mcp \
+            --cov-report=term-missing \
+            --cov-report=xml:coverage.xml \
+            --cov-fail-under=70 \
+            -v
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nixtla-airflow-operator-coverage
+          path: 005-plugins/nixtla-airflow-operator/coverage.xml
+          retention-days: 14
+
+  validator-gate:
+    name: Plugin Validator v7.0 (marketplace tier)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+        with:
+          path: plugins-nixtla
+
+      - name: Checkout claude-code-plugins
+        uses: actions/checkout@v4
+        with:
+          repository: jeremylongshore/claude-code-plugins
+          path: claude-code-plugins
+          ref: main
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install validator deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml jsonschema
+
+      - name: Validate (marketplace tier)
+        run: |
+          python claude-code-plugins/scripts/validate-skills-schema.py \
+            --marketplace \
+            plugins-nixtla/005-plugins/nixtla-airflow-operator/ \
+          || (echo "::error::Validator failed for nixtla-airflow-operator." && exit 1)

--- a/005-plugins/nixtla-airflow-operator/.claude-plugin/plugin.json
+++ b/005-plugins/nixtla-airflow-operator/.claude-plugin/plugin.json
@@ -1,8 +1,22 @@
 {
   "name": "nixtla-airflow-operator",
-  "description": "Apache Airflow operator for TimeGPT forecasting DAGs. Generate production-ready forecasting pipelines with monitoring.",
-  "version": "0.1.0",
+  "version": "1.0.0",
+  "description": "Real Apache Airflow tooling for TimeGPT forecasting pipelines. Generate production-ready DAGs (BigQuery / Snowflake / Postgres / S3 sources), AST + DagBag-based DAG validation with credential lint, real Airflow Connection JSON for 5 source types, and pytest test modules that load the DAG via DagBag.",
   "author": {
-    "name": "Intent Solutions"
-  }
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io",
+    "url": "https://github.com/jeremylongshore"
+  },
+  "homepage": "https://github.com/jeremylongshore/plugins-nixtla",
+  "repository": "https://github.com/jeremylongshore/plugins-nixtla",
+  "license": "MIT",
+  "keywords": [
+    "nixtla",
+    "timegpt",
+    "airflow",
+    "dag",
+    "orchestration",
+    "forecasting"
+  ],
+  "commands": "./commands"
 }

--- a/005-plugins/nixtla-airflow-operator/README.md
+++ b/005-plugins/nixtla-airflow-operator/README.md
@@ -1,32 +1,82 @@
 # Nixtla Airflow Operator
 
-Generate production-ready Airflow DAGs for TimeGPT forecasting.
+Real Airflow tooling for production TimeGPT forecasting pipelines. Generates DAGs targeting BigQuery / Snowflake / Postgres / S3, validates them via AST + (when available) DagBag, produces real Airflow Connection JSON for 5 source types, and emits pytest test modules that exercise the DAG structure.
 
-## Features
+**Version**: 1.0.0 · **Status**: Working · **API key needed**: For runtime, `NIXTLA_API_KEY` (Airflow tasks call `NixtlaClient`)
 
-- **DAG Generation**: Production-ready Python DAG files
-- **Multiple Sources**: BigQuery, Snowflake, Postgres, S3
-- **Monitoring**: Built-in alerting and retries
-- **Testing**: Auto-generated test files
+---
 
-## Quick Start
+## 30-second pitch
+
+Most Nixtla customers running production forecasts need an Airflow pipeline. This plugin produces a real one — extract from your warehouse, run TimeGPT, write back — with retry logic + email alerts + per-source connection config + a pytest module that asserts the DAG loads, has the expected tasks, and has no orphans.
+
+---
+
+## Quick start
 
 ```bash
+cd 005-plugins/nixtla-airflow-operator
 pip install -r scripts/requirements.txt
 
 # In Claude Code:
-/nixtla-airflow-dag my_forecast_dag --schedule=@daily --source=bigquery
+# 1. "Generate an Airflow DAG named retail_forecast for BigQuery, daily, horizon 14."
+# 2. "Validate that DAG file."
+# 3. "Configure an Airflow connection for nixtla with my API key."
+# 4. "Generate the pytest module for retail_forecast."
 ```
 
-## MCP Tools
+---
 
-| Tool | Description |
-|------|-------------|
-| `generate_dag` | Generate Airflow DAG Python file |
-| `validate_dag` | Validate DAG syntax |
-| `configure_connection` | Set up data source connection |
-| `generate_tests` | Create DAG test file |
+## MCP tools
+
+| Tool | What it does |
+|---|---|
+| `generate_dag` | Real Python DAG file: `extract_data → run_forecast → load_results`, default_args + retries + email alerts, BigQuery/Snowflake/Postgres/S3 sources |
+| `validate_dag` | Syntax check + AST extraction (task IDs, DAG id, duplicates) + optional DagBag load (when airflow installed) + lint for hardcoded credentials / missing schedule / missing default_args |
+| `configure_connection` | Real Airflow Connection JSON for **nixtla**, **bigquery**, **snowflake**, **postgres**, **s3** + the `airflow connections add` CLI command |
+| `generate_tests` | Real pytest module that loads the DAG via DagBag and asserts: import errors empty, DAG present, expected task IDs, no orphan tasks |
+
+---
+
+## Connection types supported
+
+`configure_connection` produces real Airflow Connection JSON for:
+
+| Source | Required config | Notes |
+|---|---|---|
+| `nixtla` | `api_key` | HTTP connection, password = api_key |
+| `bigquery` | `project_id` (+ optional `key_path`) | google_cloud_platform conn_type |
+| `snowflake` | `account`, `user`, `password`, `warehouse`, `database`, `schema` | host = `<account>.snowflakecomputing.com` |
+| `postgres` | `host`, `port`, `user`, `password`, `database` | postgres conn_type |
+| `s3` | `aws_access_key_id`, `aws_secret_access_key` (+ optional `region_name`) | aws conn_type, defaults region us-east-1 |
+
+Returns the JSON + the exact `airflow connections add <conn_id> --conn-json '<json>'` CLI command.
+
+---
+
+## Validator catches
+
+`validate_dag` catches these in addition to syntax:
+
+- **Duplicate `task_id`** — common copy-paste bug; flagged as error
+- **Hardcoded credentials** — `password=`, `api_key=`, `secret=`, AWS access key IDs (`AKIA...`); flagged as warning unless they reference `Variable.get` or `var.value`
+- **Missing `schedule_interval` / `schedule`** — warning
+- **Missing `default_args`** — warning (no retries / email config)
+- **DagBag import errors** (when airflow is installed in the environment) — error
+
+---
+
+## Tests
+
+```bash
+cd 005-plugins/nixtla-airflow-operator
+PYTHONPATH=scripts pytest tests/ --cov=airflow_mcp -v
+```
+
+25 tests covering DAG generation template substitution, validate_dag (valid/syntax-error/dupes/hardcoded creds/missing default_args/missing file), all 5 connection types with required-field validation, generate_tests with task ID extraction + default fallback, and async MCP dispatch.
+
+---
 
 ## License
 
-Proprietary - Intent Solutions
+MIT — Jeremy Longshore.

--- a/005-plugins/nixtla-airflow-operator/scripts/airflow_mcp.py
+++ b/005-plugins/nixtla-airflow-operator/scripts/airflow_mcp.py
@@ -1,21 +1,28 @@
 #!/usr/bin/env python3
 """MCP Server for Nixtla Airflow Operator.
 
-Exposes 4 tools:
-- generate_dag: Generate Airflow DAG Python file
-- validate_dag: Validate DAG syntax and connections
-- configure_connection: Set up data source connection
-- generate_tests: Create DAG test file
+Real implementations for:
+  - generate_dag: produce a runnable Airflow DAG file targeting a chosen source.
+  - validate_dag: AST + (optional) DagBag validation with lint warnings.
+  - configure_connection: real Airflow Connection JSON for nixtla / bigquery /
+    snowflake / postgres / s3, plus the `airflow connections add` CLI command.
+  - generate_tests: produce a real pytest module that loads the DAG via DagBag
+    and asserts structure (task IDs, dependency graph).
 """
 
+from __future__ import annotations
+
+import ast
 import json
-from typing import Any
+import re
+from typing import Any, Optional
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
 app = Server("nixtla-airflow-operator")
+
 
 DAG_TEMPLATE = '''"""
 Nixtla TimeGPT Forecasting DAG
@@ -99,6 +106,404 @@ with DAG(
 '''
 
 
+# ---------------------------------------------------------------------------
+# Tool: validate_dag
+# ---------------------------------------------------------------------------
+
+
+def _ast_extract_task_ids(tree: ast.Module) -> list[str]:
+    """Walk the AST and pull out task_id keyword args from Operator() calls."""
+    task_ids: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "task_id" and isinstance(kw.value, ast.Constant):
+                    if isinstance(kw.value.value, str):
+                        task_ids.append(kw.value.value)
+    return task_ids
+
+
+def _ast_extract_dag_id(tree: ast.Module) -> Optional[str]:
+    """Find the DAG id from a `DAG(<id>, ...)` or `with DAG(<id>, ...)` construct."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = None
+            if isinstance(func, ast.Name):
+                name = func.id
+            elif isinstance(func, ast.Attribute):
+                name = func.attr
+            if name == "DAG" and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    return first.value
+    return None
+
+
+def _lint_warnings(source: str) -> list[dict[str, Any]]:
+    """Return repo-policy lint warnings (deprecated patterns, hardcoded creds)."""
+    warnings: list[dict[str, Any]] = []
+
+    # Hardcoded credentials.
+    cred_patterns = [
+        (r'(password|api_key|secret|token)\s*=\s*["\'][^"\']{4,}["\']', "hardcoded credential"),
+        (r"AKIA[0-9A-Z]{16}", "AWS access key id"),
+    ]
+    for line_no, line in enumerate(source.splitlines(), start=1):
+        # Skip lines containing template variables (e.g., var.value.api_key).
+        if "var.value" in line or "Variable.get" in line:
+            continue
+        for pat, label in cred_patterns:
+            if re.search(pat, line, re.IGNORECASE):
+                warnings.append(
+                    {
+                        "severity": "warning",
+                        "message": f"possible {label} on line {line_no}",
+                        "line": line_no,
+                    }
+                )
+                break
+
+    # Missing schedule.
+    if "schedule_interval" not in source and "schedule=" not in source:
+        warnings.append(
+            {
+                "severity": "warning",
+                "message": "DAG has no schedule_interval / schedule keyword",
+                "line": None,
+            }
+        )
+
+    # Missing default_args.
+    if "default_args" not in source:
+        warnings.append(
+            {
+                "severity": "warning",
+                "message": "DAG missing default_args (no retries / email config)",
+                "line": None,
+            }
+        )
+
+    return warnings
+
+
+def validate_dag(dag_path: Optional[str] = None, source: Optional[str] = None) -> dict[str, Any]:
+    """Validate a DAG file (or source string) for syntax + structure + lint."""
+    if source is None:
+        if dag_path is None:
+            return {
+                "valid": False,
+                "errors": [
+                    {
+                        "severity": "error",
+                        "message": "must provide dag_path or source",
+                        "line": None,
+                    }
+                ],
+                "task_count": 0,
+                "dag_id": None,
+            }
+        try:
+            with open(dag_path, "r", encoding="utf-8") as f:
+                source = f.read()
+        except FileNotFoundError:
+            return {
+                "valid": False,
+                "errors": [
+                    {"severity": "error", "message": f"file not found: {dag_path}", "line": None}
+                ],
+                "task_count": 0,
+                "dag_id": None,
+            }
+
+    errors: list[dict[str, Any]] = []
+
+    # Syntax check.
+    try:
+        compile(source, dag_path or "<string>", "exec")
+    except SyntaxError as exc:
+        errors.append(
+            {
+                "severity": "error",
+                "message": f"syntax error: {exc.msg}",
+                "line": exc.lineno,
+            }
+        )
+
+    # AST inspection.
+    task_ids: list[str] = []
+    dag_id: Optional[str] = None
+    if not errors:
+        tree = ast.parse(source)
+        task_ids = _ast_extract_task_ids(tree)
+        dag_id = _ast_extract_dag_id(tree)
+
+        # Duplicate task IDs.
+        seen: set[str] = set()
+        for tid in task_ids:
+            if tid in seen:
+                errors.append(
+                    {
+                        "severity": "error",
+                        "message": f"duplicate task_id: {tid}",
+                        "line": None,
+                    }
+                )
+            seen.add(tid)
+
+    # Optional DagBag load.
+    dagbag_loaded = False
+    try:
+        from airflow.models.dagbag import DagBag  # type: ignore[import-untyped]
+
+        if dag_path is not None:
+            db = DagBag(dag_folder=dag_path, include_examples=False)
+            if db.import_errors:
+                for path, msg in db.import_errors.items():
+                    errors.append(
+                        {
+                            "severity": "error",
+                            "message": f"DagBag import error on {path}: {msg}",
+                            "line": None,
+                        }
+                    )
+            else:
+                dagbag_loaded = True
+    except ImportError:
+        # Airflow not installed; AST validation is the fallback.
+        pass
+
+    warnings = _lint_warnings(source)
+
+    return {
+        "valid": len(errors) == 0,
+        "errors": errors,
+        "warnings": warnings,
+        "task_count": len(task_ids),
+        "task_ids": task_ids,
+        "dag_id": dag_id,
+        "dagbag_loaded": dagbag_loaded,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool: configure_connection
+# ---------------------------------------------------------------------------
+
+
+def configure_connection(
+    source: str, connection_id: str, config: Optional[dict[str, Any]] = None
+) -> dict[str, Any]:
+    """Generate a real Airflow Connection JSON + the CLI command to register it."""
+    config = config or {}
+    src = source.lower().strip()
+
+    if src == "nixtla":
+        required = ["api_key"]
+        missing = [k for k in required if k not in config]
+        if missing:
+            return {
+                "status": "error",
+                "message": f"required fields missing for nixtla: {missing}",
+            }
+        conn = {
+            "conn_type": "http",
+            "host": config.get("host", "https://api.nixtla.io"),
+            "password": config["api_key"],
+            "extra": json.dumps({"endpoint": "/timegpt-1"}),
+        }
+
+    elif src == "bigquery":
+        required = ["project_id"]
+        missing = [k for k in required if k not in config]
+        if missing:
+            return {
+                "status": "error",
+                "message": f"required fields missing for bigquery: {missing}",
+            }
+        extra = {"project": config["project_id"]}
+        if "key_path" in config:
+            extra["key_path"] = config["key_path"]
+        conn = {"conn_type": "google_cloud_platform", "extra": json.dumps(extra)}
+
+    elif src == "snowflake":
+        required = ["account", "user", "password", "warehouse", "database", "schema"]
+        missing = [k for k in required if k not in config]
+        if missing:
+            return {
+                "status": "error",
+                "message": f"required fields missing for snowflake: {missing}",
+            }
+        conn = {
+            "conn_type": "snowflake",
+            "host": f"{config['account']}.snowflakecomputing.com",
+            "login": config["user"],
+            "password": config["password"],
+            "schema": config["schema"],
+            "extra": json.dumps(
+                {
+                    "account": config["account"],
+                    "warehouse": config["warehouse"],
+                    "database": config["database"],
+                }
+            ),
+        }
+
+    elif src == "postgres":
+        required = ["host", "port", "user", "password", "database"]
+        missing = [k for k in required if k not in config]
+        if missing:
+            return {
+                "status": "error",
+                "message": f"required fields missing for postgres: {missing}",
+            }
+        conn = {
+            "conn_type": "postgres",
+            "host": config["host"],
+            "port": int(config["port"]),
+            "login": config["user"],
+            "password": config["password"],
+            "schema": config["database"],
+        }
+
+    elif src == "s3":
+        required = ["aws_access_key_id", "aws_secret_access_key"]
+        missing = [k for k in required if k not in config]
+        if missing:
+            return {
+                "status": "error",
+                "message": f"required fields missing for s3: {missing}",
+            }
+        conn = {
+            "conn_type": "aws",
+            "login": config["aws_access_key_id"],
+            "password": config["aws_secret_access_key"],
+            "extra": json.dumps({"region_name": config.get("region_name", "us-east-1")}),
+        }
+
+    else:
+        return {
+            "status": "error",
+            "message": f"unsupported source: {source}. Supported: nixtla, bigquery, snowflake, postgres, s3",
+        }
+
+    cli_command = (
+        f"airflow connections add {connection_id} " f"--conn-json '{json.dumps(conn, default=str)}'"
+    )
+
+    return {
+        "status": "success",
+        "connection_id": connection_id,
+        "source": src,
+        "connection": conn,
+        "cli_command": cli_command,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool: generate_tests
+# ---------------------------------------------------------------------------
+
+
+TEST_MODULE_TEMPLATE = '''"""
+Tests for the {dag_id} DAG.
+Generated by nixtla-airflow-operator.
+
+Run from your Airflow project root:
+    pytest dags/tests/{test_filename} -v
+"""
+
+import pytest
+
+try:
+    from airflow.models.dagbag import DagBag
+except ImportError:
+    pytest.skip("airflow not installed; skipping DAG tests", allow_module_level=True)
+
+
+DAG_ID = "{dag_id}"
+EXPECTED_TASK_IDS = {task_ids!r}
+
+
+@pytest.fixture(scope="module")
+def dagbag():
+    return DagBag(dag_folder="dags/", include_examples=False)
+
+
+def test_dag_loads_without_errors(dagbag):
+    assert dagbag.import_errors == {{}}, f"DAG import errors: {{dagbag.import_errors}}"
+
+
+def test_dag_present(dagbag):
+    assert DAG_ID in dagbag.dags, f"DAG {{DAG_ID}} not found in dagbag"
+
+
+def test_dag_has_expected_tasks(dagbag):
+    dag = dagbag.dags[DAG_ID]
+    actual = set(t.task_id for t in dag.tasks)
+    expected = set(EXPECTED_TASK_IDS)
+    assert actual == expected, f"task mismatch: actual={{actual}} expected={{expected}}"
+
+
+def test_dag_no_orphan_tasks(dagbag):
+    """Every task except the source must have an upstream task."""
+    dag = dagbag.dags[DAG_ID]
+    for task in dag.tasks:
+        if task.upstream_list or task.downstream_list:
+            continue
+        if len(dag.tasks) > 1:
+            pytest.fail(f"orphan task: {{task.task_id}} has no upstream/downstream")
+'''
+
+
+def generate_tests(
+    dag_name: str, source: Optional[str] = None, dag_path: Optional[str] = None
+) -> dict[str, Any]:
+    """Generate a real pytest module that exercises the DAG via DagBag."""
+    task_ids: list[str] = []
+
+    # Try to discover task IDs from the source / file.
+    if source is None and dag_path is not None:
+        try:
+            with open(dag_path, "r", encoding="utf-8") as f:
+                source = f.read()
+        except FileNotFoundError:
+            source = None
+
+    if source:
+        try:
+            tree = ast.parse(source)
+            task_ids = _ast_extract_task_ids(tree)
+        except SyntaxError:
+            task_ids = []
+
+    if not task_ids:
+        # Fallback to the canonical 3-task DAG generated by generate_dag.
+        task_ids = ["extract_data", "run_forecast", "load_results"]
+
+    test_filename = f"test_{dag_name}.py"
+    test_module = TEST_MODULE_TEMPLATE.format(
+        dag_id=dag_name, task_ids=task_ids, test_filename=test_filename
+    )
+
+    return {
+        "status": "success",
+        "test_module": test_module,
+        "test_filename": test_filename,
+        "dag_id": dag_name,
+        "expected_task_ids": task_ids,
+        "instructions": (
+            f"Place this in your Airflow project's dags/tests/ directory and run: "
+            f"pytest dags/tests/{test_filename} -v"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# MCP server surface
+# ---------------------------------------------------------------------------
+
+
 @app.list_tools()
 async def list_tools() -> list[Tool]:
     return [
@@ -123,28 +528,41 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="validate_dag",
-            description="Validate DAG syntax and connections",
+            description="Validate DAG syntax + AST structure + DagBag (when airflow installed) + lint",
             inputSchema={
                 "type": "object",
-                "properties": {"dag_path": {"type": "string"}},
-                "required": ["dag_path"],
+                "properties": {
+                    "dag_path": {"type": "string"},
+                    "source": {"type": "string"},
+                },
             },
         ),
         Tool(
             name="configure_connection",
-            description="Generate Airflow connection configuration",
+            description=(
+                "Generate Airflow Connection JSON for nixtla / bigquery / snowflake "
+                "/ postgres / s3, plus the airflow connections add CLI command"
+            ),
             inputSchema={
                 "type": "object",
-                "properties": {"source": {"type": "string"}, "connection_id": {"type": "string"}},
+                "properties": {
+                    "source": {"type": "string"},
+                    "connection_id": {"type": "string"},
+                    "config": {"type": "object"},
+                },
                 "required": ["source", "connection_id"],
             },
         ),
         Tool(
             name="generate_tests",
-            description="Generate DAG test file",
+            description="Generate pytest module that loads the DAG via DagBag + asserts structure",
             inputSchema={
                 "type": "object",
-                "properties": {"dag_name": {"type": "string"}},
+                "properties": {
+                    "dag_name": {"type": "string"},
+                    "source": {"type": "string"},
+                    "dag_path": {"type": "string"},
+                },
                 "required": ["dag_name"],
             },
         ),
@@ -165,13 +583,24 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return [TextContent(type="text", text=dag_code)]
 
     elif name == "validate_dag":
-        return [TextContent(type="text", text="DAG validation: PASSED")]
+        result = validate_dag(dag_path=arguments.get("dag_path"), source=arguments.get("source"))
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "configure_connection":
-        return [TextContent(type="text", text="Connection configuration generated")]
+        result = configure_connection(
+            source=str(arguments["source"]),
+            connection_id=str(arguments["connection_id"]),
+            config=arguments.get("config", {}),
+        )
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "generate_tests":
-        return [TextContent(type="text", text="Test file generated")]
+        result = generate_tests(
+            dag_name=str(arguments["dag_name"]),
+            source=arguments.get("source"),
+            dag_path=arguments.get("dag_path"),
+        )
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     return [TextContent(type="text", text=f"Unknown tool: {name}")]
 

--- a/005-plugins/nixtla-airflow-operator/tests/conftest.py
+++ b/005-plugins/nixtla-airflow-operator/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest fixtures for nixtla-airflow-operator tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))

--- a/005-plugins/nixtla-airflow-operator/tests/test_airflow_mcp.py
+++ b/005-plugins/nixtla-airflow-operator/tests/test_airflow_mcp.py
@@ -1,0 +1,299 @@
+"""Unit tests for nixtla-airflow-operator MCP server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import airflow_mcp as mcp
+import pytest
+
+VALID_DAG_SOURCE = """
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+default_args = {
+    "owner": "data-team",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+def extract_data():
+    pass
+
+def run_forecast():
+    pass
+
+with DAG(
+    "test_dag",
+    default_args=default_args,
+    schedule_interval="@daily",
+    start_date=datetime(2024, 1, 1),
+) as dag:
+    extract = PythonOperator(task_id="extract_data", python_callable=extract_data)
+    forecast = PythonOperator(task_id="run_forecast", python_callable=run_forecast)
+    extract >> forecast
+"""
+
+
+SYNTAX_ERROR_DAG = """
+from airflow import DAG
+
+with DAG("broken" as dag:
+    pass
+"""
+
+
+DAG_WITH_DUPES = """
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+with DAG("dupes", schedule_interval="@daily", start_date=datetime(2024,1,1)) as dag:
+    a = PythonOperator(task_id="same", python_callable=lambda: None)
+    b = PythonOperator(task_id="same", python_callable=lambda: None)
+"""
+
+
+DAG_WITH_HARDCODED_KEY = """
+from airflow import DAG
+
+api_key = "supersecret_abc123_value"  # this should be flagged
+
+with DAG("k", schedule_interval="@daily", start_date=datetime(2024,1,1)) as dag:
+    pass
+"""
+
+
+# ---------------------------------------------------------------------------
+# generate_dag
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateDag:
+    def test_dag_template_substitution(self):
+        # Direct call_tool to exercise the dispatch.
+        async def go():
+            return await mcp.call_tool(
+                "generate_dag",
+                {
+                    "dag_name": "my_test_dag",
+                    "schedule": "@hourly",
+                    "source": "bigquery",
+                    "horizon": 21,
+                    "freq": "H",
+                    "alert_email": "team@example.com",
+                },
+            )
+
+        result = asyncio.run(go())
+        text = result[0].text
+        assert "my_test_dag" in text
+        assert "@hourly" in text
+        assert "h=21" in text
+        assert "freq='H'" in text
+        assert "team@example.com" in text
+
+
+# ---------------------------------------------------------------------------
+# validate_dag
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDag:
+    def test_valid_dag(self):
+        result = mcp.validate_dag(source=VALID_DAG_SOURCE)
+        assert result["valid"] is True
+        assert result["task_count"] == 2
+        assert "extract_data" in result["task_ids"]
+        assert "run_forecast" in result["task_ids"]
+        assert result["dag_id"] == "test_dag"
+
+    def test_syntax_error(self):
+        result = mcp.validate_dag(source=SYNTAX_ERROR_DAG)
+        assert result["valid"] is False
+        assert any("syntax" in e["message"].lower() for e in result["errors"])
+
+    def test_duplicate_task_ids_flagged(self):
+        result = mcp.validate_dag(source=DAG_WITH_DUPES)
+        assert any("duplicate" in e["message"].lower() for e in result["errors"])
+
+    def test_hardcoded_credential_flagged_as_warning(self):
+        result = mcp.validate_dag(source=DAG_WITH_HARDCODED_KEY)
+        assert any("credential" in w["message"].lower() for w in result["warnings"])
+
+    def test_missing_default_args_warned(self):
+        source = """
+from airflow import DAG
+from datetime import datetime
+
+with DAG("no_defaults", schedule_interval="@daily", start_date=datetime(2024,1,1)) as dag:
+    pass
+"""
+        result = mcp.validate_dag(source=source)
+        assert any("default_args" in w["message"] for w in result["warnings"])
+
+    def test_missing_dag_path_and_source_returns_error(self):
+        result = mcp.validate_dag()
+        assert result["valid"] is False
+
+    def test_missing_file_returns_error(self):
+        result = mcp.validate_dag(dag_path="/nonexistent/dag.py")
+        assert result["valid"] is False
+        assert any("file not found" in e["message"].lower() for e in result["errors"])
+
+
+# ---------------------------------------------------------------------------
+# configure_connection
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureConnection:
+    def test_nixtla(self):
+        result = mcp.configure_connection(
+            source="nixtla", connection_id="nixtla_default", config={"api_key": "test123"}
+        )
+        assert result["status"] == "success"
+        assert result["connection"]["conn_type"] == "http"
+        assert result["connection"]["password"] == "test123"
+        assert "airflow connections add nixtla_default" in result["cli_command"]
+
+    def test_bigquery_requires_project_id(self):
+        result = mcp.configure_connection(source="bigquery", connection_id="bq", config={})
+        assert result["status"] == "error"
+        assert "project_id" in result["message"]
+
+    def test_bigquery_with_project_id(self):
+        result = mcp.configure_connection(
+            source="bigquery", connection_id="bq", config={"project_id": "my-proj"}
+        )
+        assert result["status"] == "success"
+        extra = json.loads(result["connection"]["extra"])
+        assert extra["project"] == "my-proj"
+
+    def test_snowflake_complete(self):
+        result = mcp.configure_connection(
+            source="snowflake",
+            connection_id="snow",
+            config={
+                "account": "abc",
+                "user": "u",
+                "password": "p",
+                "warehouse": "w",
+                "database": "d",
+                "schema": "s",
+            },
+        )
+        assert result["status"] == "success"
+        assert result["connection"]["host"] == "abc.snowflakecomputing.com"
+
+    def test_snowflake_missing_field(self):
+        result = mcp.configure_connection(
+            source="snowflake", connection_id="snow", config={"account": "abc"}
+        )
+        assert result["status"] == "error"
+
+    def test_postgres(self):
+        result = mcp.configure_connection(
+            source="postgres",
+            connection_id="pg",
+            config={
+                "host": "localhost",
+                "port": 5432,
+                "user": "u",
+                "password": "p",
+                "database": "d",
+            },
+        )
+        assert result["status"] == "success"
+        assert result["connection"]["port"] == 5432
+
+    def test_s3_with_region(self):
+        result = mcp.configure_connection(
+            source="s3",
+            connection_id="s3default",
+            config={
+                "aws_access_key_id": "AKIA",
+                "aws_secret_access_key": "secret",
+                "region_name": "eu-west-1",
+            },
+        )
+        assert result["status"] == "success"
+        extra = json.loads(result["connection"]["extra"])
+        assert extra["region_name"] == "eu-west-1"
+
+    def test_unknown_source(self):
+        result = mcp.configure_connection(source="oracle", connection_id="x")
+        assert result["status"] == "error"
+        assert "unsupported" in result["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# generate_tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateTests:
+    def test_with_source_extracts_task_ids(self):
+        result = mcp.generate_tests(dag_name="test_dag", source=VALID_DAG_SOURCE)
+        assert result["status"] == "success"
+        assert "extract_data" in result["expected_task_ids"]
+        assert "run_forecast" in result["expected_task_ids"]
+        assert "test_test_dag.py" == result["test_filename"]
+
+    def test_no_source_uses_default_task_ids(self):
+        result = mcp.generate_tests(dag_name="default_dag")
+        assert result["expected_task_ids"] == ["extract_data", "run_forecast", "load_results"]
+
+    def test_test_module_uses_dagbag(self):
+        result = mcp.generate_tests(dag_name="d", source=VALID_DAG_SOURCE)
+        assert "from airflow.models.dagbag import DagBag" in result["test_module"]
+        assert "test_dag_loads_without_errors" in result["test_module"]
+        assert "test_dag_present" in result["test_module"]
+
+    def test_includes_run_instructions(self):
+        result = mcp.generate_tests(dag_name="x")
+        assert "pytest dags/tests/test_x.py" in result["instructions"]
+
+
+# ---------------------------------------------------------------------------
+# call_tool dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestCallTool:
+    @pytest.fixture
+    def run(self):
+        def _run(coro):
+            return asyncio.run(coro)
+
+        return _run
+
+    def test_validate_dag_dispatch(self, run):
+        result = run(mcp.call_tool("validate_dag", {"source": VALID_DAG_SOURCE}))
+        parsed = json.loads(result[0].text)
+        assert parsed["valid"] is True
+
+    def test_configure_connection_dispatch(self, run):
+        result = run(
+            mcp.call_tool(
+                "configure_connection",
+                {"source": "nixtla", "connection_id": "n", "config": {"api_key": "k"}},
+            )
+        )
+        parsed = json.loads(result[0].text)
+        assert parsed["status"] == "success"
+
+    def test_generate_tests_dispatch(self, run):
+        result = run(mcp.call_tool("generate_tests", {"dag_name": "x"}))
+        parsed = json.loads(result[0].text)
+        assert parsed["status"] == "success"
+
+    def test_unknown_tool(self, run):
+        result = run(mcp.call_tool("zzz", {}))
+        assert "Unknown" in result[0].text
+
+    def test_list_tools_includes_all_four(self, run):
+        tools = run(mcp.list_tools())
+        names = {t.name for t in tools}
+        assert names == {"generate_dag", "validate_dag", "configure_connection", "generate_tests"}


### PR DESCRIPTION
Closes Epic 1.6 (`nixtla-jqn`). Plugin **nixtla-airflow-operator** at v1.0 — full real-implementation replacement of 3 prior hardcoded stubs.

| Tool | Real behavior |
|---|---|
| `generate_dag` | Working DAG template, BigQuery/Snowflake/Postgres/S3 sources |
| `validate_dag` | Syntax + AST extraction + DagBag (optional) + lint (creds, schedule, default_args) |
| `configure_connection` | Real Airflow Connection JSON for 5 source types + CLI command |
| `generate_tests` | Real pytest module loading DAG via DagBag with structure assertions |

**Gates green**: 25/25 tests, validator marketplace tier zero errors, black+isort clean.

Anchored: `000-docs/131-AT-PLAN-plugin-build-roadmap.md` Phase 1 / Epic 1.6.