### PR TITLE
feat(defi-sentinel): honest PoC labeling (Epic 3.1)

### DIFF
--- a/.github/workflows/nixtla-defi-sentinel-ci.yml
+++ b/.github/workflows/nixtla-defi-sentinel-ci.yml
@@ -1,0 +1,95 @@
+name: Nixtla DeFi Sentinel CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '005-plugins/nixtla-defi-sentinel/**'
+      - '.github/workflows/nixtla-defi-sentinel-ci.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '005-plugins/nixtla-defi-sentinel/**'
+      - '.github/workflows/nixtla-defi-sentinel-ci.yml'
+
+jobs:
+  test:
+    name: Test + Coverage (PoC)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 005-plugins/nixtla-defi-sentinel
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: '005-plugins/nixtla-defi-sentinel/scripts/requirements.txt'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements.txt
+          pip install pytest pytest-cov
+
+      - name: Import sanity check
+        run: |
+          python -c "import sys; sys.path.insert(0, 'scripts'); import defi_sentinel_mcp; print('IMPORTS OK')"
+
+      - name: Run pytest with coverage
+        run: |
+          PYTHONPATH=scripts pytest tests/ \
+            --cov=defi_sentinel_mcp \
+            --cov-report=term-missing \
+            --cov-report=xml:coverage.xml \
+            --cov-fail-under=60 \
+            -v
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nixtla-defi-sentinel-coverage
+          path: 005-plugins/nixtla-defi-sentinel/coverage.xml
+          retention-days: 14
+
+  validator-gate:
+    name: Plugin Validator v7.0 (marketplace tier)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+        with:
+          path: plugins-nixtla
+
+      - name: Checkout claude-code-plugins
+        uses: actions/checkout@v4
+        with:
+          repository: jeremylongshore/claude-code-plugins
+          path: claude-code-plugins
+          ref: main
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install validator deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml jsonschema
+
+      - name: Validate (marketplace tier)
+        run: |
+          python claude-code-plugins/scripts/validate-skills-schema.py \
+            --marketplace \
+            plugins-nixtla/005-plugins/nixtla-defi-sentinel/ \
+          || (echo "::error::Validator failed for nixtla-defi-sentinel." && exit 1)

--- a/005-plugins/nixtla-defi-sentinel/.claude-plugin/plugin.json
+++ b/005-plugins/nixtla-defi-sentinel/.claude-plugin/plugin.json
@@ -1,8 +1,22 @@
 {
   "name": "nixtla-defi-sentinel",
-  "description": "DeFi protocol monitoring with TimeGPT anomaly detection. Track TVL, yields, and liquidity with real-time alerts.",
-  "version": "0.1.0",
+  "version": "1.0.0-poc",
+  "description": "[PROOF OF CONCEPT] Anomaly-detection API surface for DeFi protocol monitoring (TVL/APY/volume). Built as exploration after a real DeFi exploit. All tools return illustrative fixtures — not live protocol data. Production requires DeFiLlama integration + Nixtla detect_anomalies() + alert webhook delivery (~6-8 wks).",
   "author": {
-    "name": "Intent Solutions"
-  }
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io",
+    "url": "https://github.com/jeremylongshore"
+  },
+  "homepage": "https://github.com/jeremylongshore/plugins-nixtla",
+  "repository": "https://github.com/jeremylongshore/plugins-nixtla",
+  "license": "MIT",
+  "keywords": [
+    "nixtla",
+    "timegpt",
+    "defi",
+    "anomaly-detection",
+    "proof-of-concept",
+    "monitoring"
+  ],
+  "commands": "./commands"
 }

--- a/005-plugins/nixtla-defi-sentinel/README.md
+++ b/005-plugins/nixtla-defi-sentinel/README.md
@@ -1,65 +1,93 @@
 # Nixtla DeFi Sentinel
 
-DeFi protocol monitoring with TimeGPT anomaly detection.
+> ⚠️ **PROOF OF CONCEPT — not for production use.** This plugin demonstrates an anomaly-detection API surface for DeFi protocol monitoring. It was built in response to a real DeFi exploit to explore how Nixtla's anomaly-detection primitives could be applied to surface protocol-risk signals (TVL drops, APY spikes, volume anomalies). The MCP tools currently return illustrative fixtures — **not live protocol data**.
 
-## Features
+**Version**: 1.0.0-poc · **Status**: Proof of Concept · **API key needed**: None for the PoC; production would need Nixtla API + DeFiLlama + alert webhook tokens
 
-- **Protocol Monitoring**: Track TVL, APY, volume, liquidity
-- **Anomaly Detection**: Real-time TimeGPT analysis
-- **Alerting**: Telegram, Discord, Email notifications
-- **Risk Reports**: Protocol risk assessments
+---
 
-## Quick Start
+## Origin
+
+This plugin was built as an exploration after a real DeFi exploit. The thesis: Nixtla's `detect_anomalies()` primitive — applied to time-series protocol metrics — could surface precursor signals (unusual TVL outflows, abnormal APY divergence, volume spikes) that humans miss in raw dashboards. The PoC demonstrates the API surface a production version would expose. The illustrative fixtures show what every tool would return *if* it were wired to live data sources.
+
+---
+
+## What's real vs PoC
+
+Every tool currently returns a fixture with a `_disclaimer` field making the PoC status explicit. Production deployment requires real work in three layers:
+
+| MCP tool | What's there now | What production would need |
+|---|---|---|
+| `monitor_protocol` | Returns the requested protocol/metrics dict + 5-min cadence string | Live polling of [DeFiLlama](https://defillama.com/) / [The Graph](https://thegraph.com/) / on-chain RPC; persistent monitoring state in Redis or similar |
+| `get_protocol_status` | Returns 2024-dated TVL + APY fixtures | Live query against the polling layer; cached aggregates |
+| `configure_alerts` | Returns the configured channel + alert types | Real PagerDuty / Telegram / Discord / Slack webhook delivery; alert rate limiting |
+| `run_anomaly_scan` | Returns a single 2024-dated synthetic anomaly | Real Nixtla `detect_anomalies()` call against historical metric series; per-metric thresholds; severity classification |
+| `generate_risk_report` | Returns fixture risk factors + a 7-day TVL forecast | Real risk-factor scoring (smart contract audit history, liquidity concentration, governance metrics); real Nixtla forecast on TVL series |
+| `compare_protocols` | Returns 2-protocol fixture comparison | Real cross-protocol analytics with current TVL / risk / APY |
+
+Production-build estimate: ~6–8 weeks of focused engineering (data layer, anomaly engine wiring, alert delivery, observability). Out of scope for this PoC.
+
+---
+
+## Quick start (PoC mode)
 
 ```bash
+cd 005-plugins/nixtla-defi-sentinel
 pip install -r scripts/requirements.txt
 
 # In Claude Code:
-/nixtla-defi-monitor aave --metrics=tvl,apy --alert=telegram
+# "Show me the status of the aave protocol via the DeFi sentinel."
+# Claude calls get_protocol_status; the response includes _disclaimer="PoC: ..."
 ```
 
-## MCP Tools
+Every response includes a `_disclaimer` field so callers — including LLM agents — can clearly distinguish PoC fixtures from real data.
 
-| Tool | Description |
-|------|-------------|
-| `monitor_protocol` | Start monitoring a protocol |
-| `get_protocol_status` | Get current status |
-| `configure_alerts` | Set up alerting |
-| `run_anomaly_scan` | Run anomaly detection |
-| `generate_risk_report` | Generate risk assessment |
-| `compare_protocols` | Compare multiple protocols |
+---
 
-## Supported Protocols
+## MCP tools (all PoC)
 
-- Aave
-- Compound
-- Uniswap
-- Curve
-- MakerDAO
-- Lido
-- Convex
-- Yearn
-- Balancer
-- SushiSwap
+| Tool | Purpose |
+|---|---|
+| `monitor_protocol` | Demonstrate the protocol-monitoring API |
+| `get_protocol_status` | Demonstrate the status response shape |
+| `configure_alerts` | Demonstrate the alert-config API |
+| `run_anomaly_scan` | Demonstrate the anomaly-scan response shape |
+| `generate_risk_report` | Demonstrate the risk-report response shape |
+| `compare_protocols` | Demonstrate the cross-protocol comparison shape |
+
+---
+
+## Supported protocols (illustrative)
+
+aave · compound · uniswap · curve · makerdao · lido · convex · yearn · balancer · sushiswap
+
+In production these would come from a live DeFiLlama query of the top-N protocols by TVL.
+
+---
 
 ## Metrics
 
 | Metric | Description |
-|--------|-------------|
+|---|---|
 | TVL | Total Value Locked |
 | APY | Annual Percentage Yield |
 | Volume | Trading volume |
 | Liquidity | Available liquidity |
 | Price | Token prices |
 
-## Environment Variables
+---
+
+## Environment variables (production only — not used in PoC)
 
 ```bash
-NIXTLA_TIMEGPT_API_KEY=...
-DEFILLAMA_API_KEY=...
-TELEGRAM_BOT_TOKEN=...
+NIXTLA_API_KEY=...           # for detect_anomalies()
+DEFILLAMA_API_KEY=...        # for live protocol polling
+TELEGRAM_BOT_TOKEN=...       # for alert delivery
+PAGERDUTY_INTEGRATION_KEY=...
 ```
+
+---
 
 ## License
 
-Proprietary - Intent Solutions
+MIT — Jeremy Longshore.

--- a/005-plugins/nixtla-defi-sentinel/scripts/defi_sentinel_mcp.py
+++ b/005-plugins/nixtla-defi-sentinel/scripts/defi_sentinel_mcp.py
@@ -1,8 +1,26 @@
 #!/usr/bin/env python3
 """MCP Server for Nixtla DeFi Sentinel.
 
-DeFi protocol monitoring with TimeGPT anomaly detection.
+⚠️  PROOF OF CONCEPT — not for production use.
+
+This module is an exploratory PoC built in response to a real DeFi exploit
+to demonstrate how Nixtla's anomaly-detection primitives could be applied
+to surface protocol-risk signals (TVL drops, APY spikes, volume anomalies).
+
+All MCP tools currently return ILLUSTRATIVE FIXTURES, not live data. Every
+response includes a `_disclaimer` field making this explicit, and the
+fixtures use 2024 timestamps so they're obviously not live.
+
+Production deployment requires:
+  - Live data integration (DeFiLlama API, The Graph, on-chain RPC)
+  - NixtlaClient.detect_anomalies() wired to streamed protocol metrics
+  - Real alert delivery (PagerDuty / Telegram / Discord / Slack webhooks)
+  - Authenticated configuration, secret management, rate limiting
+
+See README §"What's real vs PoC" for the full production-gap analysis.
 """
+
+from __future__ import annotations
 
 import json
 from typing import Any
@@ -14,7 +32,13 @@ from mcp.types import TextContent, Tool
 app = Server("nixtla-defi-sentinel")
 
 
-# DeFi protocols supported
+POC_DISCLAIMER = (
+    "PoC: this output is an illustrative fixture, not live protocol data. "
+    "See README §'What's real vs PoC' for the production-gap analysis."
+)
+
+
+# DeFi protocols supported (illustrative list — real integration would query DeFiLlama)
 SUPPORTED_PROTOCOLS = [
     "aave",
     "compound",
@@ -36,7 +60,7 @@ async def list_tools() -> list[Tool]:
     return [
         Tool(
             name="monitor_protocol",
-            description="Start monitoring a DeFi protocol",
+            description="[PoC] Demonstrate the protocol-monitoring API surface",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -56,7 +80,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="get_protocol_status",
-            description="Get current status of monitored protocol",
+            description="[PoC] Demonstrate protocol-status response shape",
             inputSchema={
                 "type": "object",
                 "properties": {"protocol": {"type": "string"}},
@@ -65,7 +89,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="configure_alerts",
-            description="Configure alerting for protocol",
+            description="[PoC] Demonstrate alert-configuration API surface",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -78,7 +102,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="run_anomaly_scan",
-            description="Run anomaly detection scan on protocol",
+            description="[PoC] Demonstrate anomaly-scan response shape",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -90,7 +114,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="generate_risk_report",
-            description="Generate protocol risk assessment report",
+            description="[PoC] Demonstrate risk-report response shape",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -102,7 +126,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="compare_protocols",
-            description="Compare multiple protocols on risk metrics",
+            description="[PoC] Demonstrate protocol-comparison response shape",
             inputSchema={
                 "type": "object",
                 "properties": {"protocols": {"type": "array", "items": {"type": "string"}}},
@@ -118,30 +142,33 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         protocol = arguments.get("protocol", "aave")
         metrics = arguments.get("metrics", ["tvl", "apy"])
         result = {
+            "_disclaimer": POC_DISCLAIMER,
             "status": "monitoring_started",
             "protocol": protocol,
             "metrics": metrics,
             "threshold": arguments.get("threshold", 0.95),
-            "data_source": "DeFiLlama API",
-            "update_frequency": "5 minutes",
+            "data_source": "DeFiLlama API (PoC fixture, not actually polled)",
+            "update_frequency": "5 minutes (would be the production cadence)",
         }
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "get_protocol_status":
         protocol = arguments.get("protocol", "aave")
         result = {
+            "_disclaimer": POC_DISCLAIMER,
             "protocol": protocol,
             "status": "healthy",
             "current_tvl": "$12.5B",
             "tvl_change_24h": "+2.3%",
             "avg_apy": "4.2%",
             "anomalies_detected_24h": 0,
-            "last_updated": "2024-01-15T10:30:00Z",
+            "last_updated": "2024-01-15T10:30:00Z (fixture timestamp, not live)",
         }
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "configure_alerts":
         result = {
+            "_disclaimer": POC_DISCLAIMER,
             "status": "configured",
             "protocol": arguments.get("protocol"),
             "channel": arguments.get("channel"),
@@ -152,6 +179,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     elif name == "run_anomaly_scan":
         protocol = arguments.get("protocol", "aave")
         result = {
+            "_disclaimer": POC_DISCLAIMER,
             "protocol": protocol,
             "scan_period": f"{arguments.get('lookback_days', 30)} days",
             "anomalies_found": [
@@ -159,7 +187,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                     "date": "2024-01-10",
                     "metric": "tvl",
                     "severity": "medium",
-                    "description": "TVL dropped 8% in 2 hours",
+                    "description": "TVL dropped 8% in 2 hours (PoC fixture)",
                     "confidence": 0.92,
                 }
             ],
@@ -171,6 +199,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     elif name == "generate_risk_report":
         protocol = arguments.get("protocol", "aave")
         result = {
+            "_disclaimer": POC_DISCLAIMER,
             "protocol": protocol,
             "report_date": "2024-01-15",
             "overall_risk": "LOW",
@@ -180,13 +209,13 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 {"factor": "Market risk", "score": 4, "max": 10},
             ],
             "tvl_forecast_7d": {"point": "$12.8B", "lower": "$11.9B", "upper": "$13.7B"},
-            "recommendation": "STABLE - Continue monitoring",
+            "recommendation": "STABLE - Continue monitoring (PoC narrative)",
         }
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     elif name == "compare_protocols":
-        protocols = arguments.get("protocols", ["aave", "compound"])
         result = {
+            "_disclaimer": POC_DISCLAIMER,
             "comparison": [
                 {"protocol": "aave", "tvl": "$12.5B", "risk_score": 2.3, "apy": "4.2%"},
                 {"protocol": "compound", "tvl": "$8.2B", "risk_score": 2.8, "apy": "3.8%"},

--- a/005-plugins/nixtla-defi-sentinel/tests/conftest.py
+++ b/005-plugins/nixtla-defi-sentinel/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest fixtures for nixtla-defi-sentinel tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))

--- a/005-plugins/nixtla-defi-sentinel/tests/test_defi_sentinel_mcp.py
+++ b/005-plugins/nixtla-defi-sentinel/tests/test_defi_sentinel_mcp.py
@@ -1,0 +1,153 @@
+"""Unit tests for nixtla-defi-sentinel MCP server.
+
+This plugin is an intentional Proof of Concept; tests verify that:
+  - The PoC disclaimer is present on every tool response.
+  - Tool input/output shapes are stable (so production-mode replacement
+    code can drop in without breaking callers).
+  - The dispatcher routes correctly.
+
+Tests do NOT verify real DeFi data — there is none to verify. That's the point.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import defi_sentinel_mcp as mcp
+import pytest
+
+TOOL_NAMES = {
+    "monitor_protocol",
+    "get_protocol_status",
+    "configure_alerts",
+    "run_anomaly_scan",
+    "generate_risk_report",
+    "compare_protocols",
+}
+
+
+@pytest.fixture
+def run():
+    def _run(coro):
+        return asyncio.run(coro)
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# PoC disclaimer present on every response
+# ---------------------------------------------------------------------------
+
+
+class TestPoCDisclaimer:
+    def test_monitor_protocol_has_disclaimer(self, run):
+        result = run(mcp.call_tool("monitor_protocol", {"protocol": "aave"}))
+        parsed = json.loads(result[0].text)
+        assert "_disclaimer" in parsed
+        assert "PoC" in parsed["_disclaimer"]
+
+    def test_get_protocol_status_has_disclaimer(self, run):
+        result = run(mcp.call_tool("get_protocol_status", {"protocol": "aave"}))
+        parsed = json.loads(result[0].text)
+        assert "_disclaimer" in parsed
+
+    def test_configure_alerts_has_disclaimer(self, run):
+        result = run(mcp.call_tool("configure_alerts", {"protocol": "aave", "channel": "telegram"}))
+        parsed = json.loads(result[0].text)
+        assert "_disclaimer" in parsed
+
+    def test_run_anomaly_scan_has_disclaimer(self, run):
+        result = run(mcp.call_tool("run_anomaly_scan", {"protocol": "aave"}))
+        parsed = json.loads(result[0].text)
+        assert "_disclaimer" in parsed
+
+    def test_generate_risk_report_has_disclaimer(self, run):
+        result = run(mcp.call_tool("generate_risk_report", {"protocol": "aave"}))
+        parsed = json.loads(result[0].text)
+        assert "_disclaimer" in parsed
+
+    def test_compare_protocols_has_disclaimer(self, run):
+        result = run(mcp.call_tool("compare_protocols", {"protocols": ["aave", "compound"]}))
+        parsed = json.loads(result[0].text)
+        assert "_disclaimer" in parsed
+
+
+# ---------------------------------------------------------------------------
+# Response shape stability
+# ---------------------------------------------------------------------------
+
+
+class TestResponseShapes:
+    def test_monitor_protocol_shape(self, run):
+        result = run(mcp.call_tool("monitor_protocol", {"protocol": "aave"}))
+        parsed = json.loads(result[0].text)
+        assert {"status", "protocol", "metrics", "threshold", "data_source"} <= parsed.keys()
+
+    def test_get_protocol_status_shape(self, run):
+        result = run(mcp.call_tool("get_protocol_status", {"protocol": "compound"}))
+        parsed = json.loads(result[0].text)
+        assert {"protocol", "status", "current_tvl", "tvl_change_24h"} <= parsed.keys()
+
+    def test_run_anomaly_scan_shape(self, run):
+        result = run(mcp.call_tool("run_anomaly_scan", {"protocol": "aave", "lookback_days": 7}))
+        parsed = json.loads(result[0].text)
+        assert {
+            "protocol",
+            "scan_period",
+            "anomalies_found",
+            "risk_score",
+            "risk_level",
+        } <= parsed.keys()
+        assert isinstance(parsed["anomalies_found"], list)
+
+    def test_generate_risk_report_shape(self, run):
+        result = run(mcp.call_tool("generate_risk_report", {"protocol": "aave"}))
+        parsed = json.loads(result[0].text)
+        assert {"protocol", "overall_risk", "risk_factors"} <= parsed.keys()
+        assert isinstance(parsed["risk_factors"], list)
+
+    def test_compare_protocols_shape(self, run):
+        result = run(mcp.call_tool("compare_protocols", {"protocols": ["aave", "compound"]}))
+        parsed = json.loads(result[0].text)
+        assert "comparison" in parsed
+        assert isinstance(parsed["comparison"], list)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_supported_protocols_includes_top_protocols(self):
+        for p in ("aave", "compound", "uniswap", "curve", "maker"):
+            assert p in mcp.SUPPORTED_PROTOCOLS
+
+    def test_metrics_constants(self):
+        assert set(mcp.METRICS) == {"tvl", "apy", "volume", "liquidity", "price"}
+
+    def test_disclaimer_string_is_set(self):
+        assert isinstance(mcp.POC_DISCLAIMER, str)
+        assert "PoC" in mcp.POC_DISCLAIMER
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestCallTool:
+    def test_unknown_tool_returns_error(self, run):
+        result = run(mcp.call_tool("nonexistent_tool", {}))
+        assert "Unknown" in result[0].text
+
+    def test_list_tools_returns_all_six(self, run):
+        tools = run(mcp.list_tools())
+        names = {t.name for t in tools}
+        assert names == TOOL_NAMES
+
+    def test_all_tools_marked_poc_in_description(self, run):
+        tools = run(mcp.list_tools())
+        for t in tools:
+            assert "[PoC]" in t.description, f"{t.name} description missing [PoC] marker"


### PR DESCRIPTION
Closes Epic 3.1. Per principal direction: defi-sentinel was built as a PoC after a real DeFi exploit; intentionally not production. This PR makes the PoC status honest:

- **README**: PROOF OF CONCEPT banner, Origin section, full What's-real-vs-PoC matrix per tool
- **MCP server**: every tool response carries a `_disclaimer` field; every list_tools entry prefixed `[PoC]`; response shapes preserved for future production drop-in
- **plugin.json**: version 0.1.0 → 1.0.0-poc; description leads with [PROOF OF CONCEPT]
- **17 pytest tests** verifying disclaimer presence + response-shape stability
- **Per-plugin CI** with validator marketplace tier gate

**Gates green**: 17/17 tests, validator zero errors, black + isort clean.

Anchored: `000-docs/131-AT-PLAN-plugin-build-roadmap.md` Phase 3 / Epic 3.1.