### PR TITLE
feat(streaming-monitor): honest PoC labeling (Epic 3.2)

### DIFF
--- a/.github/workflows/nixtla-anomaly-streaming-monitor-ci.yml
+++ b/.github/workflows/nixtla-anomaly-streaming-monitor-ci.yml
@@ -37,7 +37,7 @@ jobs:
           pip install pytest
 
       - name: Run PoC labeling tests
-        run: pytest tests/ -v
+        run: pytest tests/ -v -o addopts="" -p no:cacheprovider
 
   validator-gate:
     name: Plugin Validator v7.0 (marketplace tier)

--- a/.github/workflows/nixtla-anomaly-streaming-monitor-ci.yml
+++ b/.github/workflows/nixtla-anomaly-streaming-monitor-ci.yml
@@ -1,0 +1,74 @@
+name: Nixtla Anomaly Streaming Monitor CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '005-plugins/nixtla-anomaly-streaming-monitor/**'
+      - '.github/workflows/nixtla-anomaly-streaming-monitor-ci.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '005-plugins/nixtla-anomaly-streaming-monitor/**'
+      - '.github/workflows/nixtla-anomaly-streaming-monitor-ci.yml'
+
+jobs:
+  test:
+    name: PoC Labeling Verification (Python tests)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 005-plugins/nixtla-anomaly-streaming-monitor
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run PoC labeling tests
+        run: pytest tests/ -v
+
+  validator-gate:
+    name: Plugin Validator v7.0 (marketplace tier)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+        with:
+          path: plugins-nixtla
+
+      - name: Checkout claude-code-plugins
+        uses: actions/checkout@v4
+        with:
+          repository: jeremylongshore/claude-code-plugins
+          path: claude-code-plugins
+          ref: main
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install validator deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml jsonschema
+
+      - name: Validate (marketplace tier)
+        run: |
+          python claude-code-plugins/scripts/validate-skills-schema.py \
+            --marketplace \
+            plugins-nixtla/005-plugins/nixtla-anomaly-streaming-monitor/ \
+          || (echo "::error::Validator failed for nixtla-anomaly-streaming-monitor." && exit 1)

--- a/005-plugins/nixtla-anomaly-streaming-monitor/.claude-plugin/plugin.json
+++ b/005-plugins/nixtla-anomaly-streaming-monitor/.claude-plugin/plugin.json
@@ -1,8 +1,23 @@
 {
   "name": "nixtla-anomaly-streaming-monitor",
-  "description": "Real-time streaming anomaly detection for Kafka/Kinesis. Detect anomalies within 30 seconds with PagerDuty/Slack alerts.",
-  "version": "0.1.0",
+  "version": "1.0.0-poc",
+  "description": "[PROOF OF CONCEPT] Anomaly-detection API surface for streaming protocol metrics (Kafka/Kinesis/webhooks). All tools return illustrative fixtures — not live stream data. Production requires real consumers + Nixtla detect_anomalies() + alert delivery (~6-10 wks).",
   "author": {
-    "name": "Intent Solutions"
-  }
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io",
+    "url": "https://github.com/jeremylongshore"
+  },
+  "homepage": "https://github.com/jeremylongshore/plugins-nixtla",
+  "repository": "https://github.com/jeremylongshore/plugins-nixtla",
+  "license": "MIT",
+  "keywords": [
+    "nixtla",
+    "timegpt",
+    "streaming",
+    "kafka",
+    "kinesis",
+    "anomaly-detection",
+    "proof-of-concept"
+  ],
+  "commands": "./commands"
 }

--- a/005-plugins/nixtla-anomaly-streaming-monitor/README.md
+++ b/005-plugins/nixtla-anomaly-streaming-monitor/README.md
@@ -1,51 +1,106 @@
 # Nixtla Anomaly Streaming Monitor
 
-Real-time streaming anomaly detection for Kafka/Kinesis with alerting.
+> ⚠️ **PROOF OF CONCEPT — not for production use.** This plugin demonstrates an anomaly-detection API surface for streaming protocol metrics (Kafka / AWS Kinesis / HTTP webhooks). All MCP tools currently return **illustrative fixtures** — not live consumer data. Production deployment is a multi-week build (real consumers, alert delivery, observability) — see *What's real vs PoC* below.
 
-## Features
+**Version**: 1.0.0-poc · **Status**: Proof of Concept · **API key needed**: None for the PoC; production would need Nixtla API + broker creds + alert webhook tokens
 
-- **Stream Sources**: Kafka, AWS Kinesis, HTTP Webhooks
-- **Real-time Detection**: <1 second latency
-- **Alerting**: PagerDuty, Slack, Email
-- **Monitoring**: Grafana dashboard, Prometheus metrics
+---
 
-## Architecture
+## Origin
+
+This plugin sketches what real-time TimeGPT-powered anomaly detection could look like for a streaming pipeline. The design demonstrates the API a SRE / platform team would use: start a monitor on a Kafka topic, get health checks, configure alerting, query stats. The PoC fixes the API surface — production code can drop in behind these tool signatures without breaking callers.
+
+---
+
+## What's real vs PoC
+
+Every tool currently returns a fixture with a `_disclaimer` field making the PoC status explicit. Production deployment requires real work in three layers:
+
+| MCP tool | What's there now | What production would need |
+|---|---|---|
+| `stream_monitor_start` | Returns a generated `monitor_id` + the requested config | Real Kafka consumer (kafkajs) or Kinesis consumer (@aws-sdk/client-kinesis) bound to a worker pool; persistent monitor state |
+| `stream_monitor_stop` | Returns `{status: stopped}` | Real consumer-shutdown + offset commit + cleanup |
+| `stream_health_check` | Returns fixture lag/EPS values | Real consumer-group lag query against the broker; per-monitor metrics from the worker |
+| `configure_alerts` | Returns `{status: configured}` | Real alert routing config persistence + validation against the chosen channel's API |
+| `get_anomaly_stats` | Returns fixture totals + anomaly rate | Real aggregation from Prometheus / time-series store; deduplication by anomaly fingerprint |
+| `export_dashboard_config` | Returns a reference to the static `config/grafana_dashboard.json` fixture | Real templated dashboard generation parameterized by the active monitors |
+
+Plus the missing bits that are out of scope here entirely:
+- Event queue between consumer and Python worker (Redis / nats / in-memory channel)
+- Python worker actually wired to `NixtlaClient.detect_anomalies()` with batch dispatch
+- Real alert delivery to PagerDuty Events API v2 / Slack webhooks / SMTP
+- Circuit breakers, dead-letter handling, structured logging, OTEL traces
+
+Production-build estimate: ~6–10 weeks of focused engineering. Out of scope for this PoC.
+
+---
+
+## Quick start (PoC mode)
+
+```bash
+cd 005-plugins/nixtla-anomaly-streaming-monitor
+
+# Install dev dependencies (when wired)
+npm install                                            # MCP server (TypeScript)
+pip install -r src/python-worker/requirements.txt 2>/dev/null || true   # Python worker
+
+# In Claude Code:
+# "Start the streaming monitor on the events kafka topic with threshold 0.95."
+# Claude calls stream_monitor_start; the response includes _disclaimer="PoC: ..."
+```
+
+Every response includes a `_disclaimer` field so callers — including LLM agents — can clearly distinguish PoC fixtures from real data.
+
+---
+
+## MCP tools (all PoC)
+
+| Tool | Purpose |
+|---|---|
+| `stream_monitor_start` | Demonstrate the start-monitor API |
+| `stream_monitor_stop` | Demonstrate the stop-monitor API |
+| `stream_health_check` | Demonstrate the consumer-health response shape |
+| `configure_alerts` | Demonstrate the alert-config API |
+| `get_anomaly_stats` | Demonstrate the stats-aggregation response shape |
+| `export_dashboard_config` | Demonstrate the dashboard-export response shape |
+
+---
+
+## Architecture (production target)
 
 ```
 ┌─────────────┐     ┌──────────────┐     ┌─────────────┐
-│   Kafka/    │────▶│   MCP Server │────▶│  TimeGPT    │
-│   Kinesis   │     │  (TypeScript)│     │   API       │
-└─────────────┘     └──────────────┘     └─────────────┘
-                           │
-                           ▼
-                    ┌──────────────┐
-                    │   Alerting   │
-                    │  (PagerDuty) │
-                    └──────────────┘
+│   Kafka/    │────▶│   Consumer   │────▶│   Worker    │
+│   Kinesis   │     │  (TS / SDK)  │     │   (Python)  │
+└─────────────┘     └──────────────┘     │ NixtlaClient│
+                                         │ .detect_    │
+                                         │ anomalies() │
+                                         └──────┬──────┘
+                                                │
+                                                ▼
+                                         ┌──────────────┐
+                                         │   Alerting   │
+                                         │ (PD / Slack /│
+                                         │   Email)     │
+                                         └──────────────┘
 ```
 
-## Quick Start
+Today only the API surface (the box on the left of the consumer) exists.
+
+---
+
+## Environment variables (production only — not used in PoC)
 
 ```bash
-# Install dependencies
-npm install
-pip install -r src/python-worker/requirements.txt
-
-# In Claude Code:
-/nixtla-stream-monitor kafka --topic=events --threshold=0.95
+NIXTLA_API_KEY=...                # for detect_anomalies()
+KAFKA_BROKERS=...                 # for kafkajs consumer
+AWS_ACCESS_KEY_ID=...             # for Kinesis consumer
+PAGERDUTY_INTEGRATION_KEY=...     # for alert delivery
+SLACK_WEBHOOK_URL=...             # for alert delivery
 ```
 
-## MCP Tools
-
-| Tool | Description |
-|------|-------------|
-| `stream_monitor_start` | Start monitoring a stream |
-| `stream_monitor_stop` | Stop monitoring |
-| `stream_health_check` | Check consumer health |
-| `configure_alerts` | Set up alerting rules |
-| `get_anomaly_stats` | Get real-time statistics |
-| `export_dashboard_config` | Generate Grafana dashboard |
+---
 
 ## License
 
-Proprietary - Intent Solutions
+MIT — Jeremy Longshore.

--- a/005-plugins/nixtla-anomaly-streaming-monitor/src/mcp-server/index.ts
+++ b/005-plugins/nixtla-anomaly-streaming-monitor/src/mcp-server/index.ts
@@ -1,8 +1,20 @@
 /**
  * Nixtla Anomaly Streaming Monitor - MCP Server
  *
- * Real-time streaming anomaly detection for Kafka/Kinesis with
- * PagerDuty/Slack alerting integration.
+ * ⚠️  PROOF OF CONCEPT — not for production use.
+ *
+ * This module is an exploratory PoC demonstrating an anomaly-detection API
+ * surface for streaming protocol metrics (Kafka / Kinesis / HTTP webhooks).
+ * All MCP tools currently return ILLUSTRATIVE FIXTURES, not live consumer
+ * data. Every response includes a `_disclaimer` field making this explicit.
+ *
+ * Production deployment requires:
+ *   - Real Kafka/Kinesis consumer code (kafkajs / @aws-sdk/client-kinesis)
+ *   - Event queue + Python-worker IPC for batch dispatch to NixtlaClient
+ *   - Real alert delivery (PagerDuty Events API / Slack webhooks / SMTP)
+ *   - Stream lag monitoring + circuit breakers + dead-letter queue handling
+ *
+ * See README §"What's real vs PoC" for the full production-gap analysis.
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -12,10 +24,14 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
+const POC_DISCLAIMER =
+  "PoC: this output is an illustrative fixture, not live stream data. " +
+  "See README §'What's real vs PoC' for the production-gap analysis.";
+
 const server = new Server(
   {
     name: "nixtla-anomaly-streaming-monitor",
-    version: "0.1.0",
+    version: "1.0.0-poc",
   },
   {
     capabilities: {
@@ -24,13 +40,13 @@ const server = new Server(
   }
 );
 
-// Tool definitions
+// Tool definitions (every description prefixed [PoC])
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: [
       {
         name: "stream_monitor_start",
-        description: "Start monitoring a stream for anomalies",
+        description: "[PoC] Demonstrate the stream-monitor-start API surface",
         inputSchema: {
           type: "object",
           properties: {
@@ -54,7 +70,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "stream_monitor_stop",
-        description: "Stop monitoring a stream",
+        description: "[PoC] Demonstrate the stream-monitor-stop API surface",
         inputSchema: {
           type: "object",
           properties: {
@@ -68,7 +84,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "stream_health_check",
-        description: "Check consumer health status",
+        description: "[PoC] Demonstrate the consumer-health response shape",
         inputSchema: {
           type: "object",
           properties: {
@@ -81,7 +97,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "configure_alerts",
-        description: "Set up alerting rules",
+        description: "[PoC] Demonstrate the alert-configuration API surface",
         inputSchema: {
           type: "object",
           properties: {
@@ -102,7 +118,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "get_anomaly_stats",
-        description: "Get real-time anomaly statistics",
+        description: "[PoC] Demonstrate the anomaly-stats response shape",
         inputSchema: {
           type: "object",
           properties: {
@@ -113,7 +129,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "export_dashboard_config",
-        description: "Generate Grafana dashboard configuration",
+        description: "[PoC] Demonstrate the Grafana dashboard config response shape",
         inputSchema: {
           type: "object",
           properties: {
@@ -125,7 +141,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   };
 });
 
-// Tool execution
+// Tool execution — every response carries _disclaimer
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
@@ -137,6 +153,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             type: "text",
             text: JSON.stringify(
               {
+                _disclaimer: POC_DISCLAIMER,
                 status: "started",
                 monitor_id: `monitor_${Date.now()}`,
                 source: args?.source,
@@ -155,7 +172,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ status: "stopped", monitor_id: args?.monitor_id }),
+            text: JSON.stringify({
+              _disclaimer: POC_DISCLAIMER,
+              status: "stopped",
+              monitor_id: args?.monitor_id,
+            }),
           },
         ],
       };
@@ -166,6 +187,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           {
             type: "text",
             text: JSON.stringify({
+              _disclaimer: POC_DISCLAIMER,
               status: "healthy",
               lag: 0,
               events_per_second: 1250,
@@ -180,7 +202,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ status: "configured", channel: args?.channel }),
+            text: JSON.stringify({
+              _disclaimer: POC_DISCLAIMER,
+              status: "configured",
+              channel: args?.channel,
+            }),
           },
         ],
       };
@@ -191,6 +217,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           {
             type: "text",
             text: JSON.stringify({
+              _disclaimer: POC_DISCLAIMER,
               timeframe: args?.timeframe || "1h",
               total_events: 4500000,
               anomalies_detected: 127,
@@ -206,7 +233,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         content: [
           {
             type: "text",
-            text: "Grafana dashboard config exported to config/grafana_dashboard.json",
+            text: JSON.stringify({
+              _disclaimer: POC_DISCLAIMER,
+              status: "exported",
+              path: "config/grafana_dashboard.json",
+              note: "Static fixture — see file in repo for the dashboard JSON shape.",
+            }),
           },
         ],
       };
@@ -221,7 +253,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("Nixtla Anomaly Streaming Monitor MCP server running");
+  console.error("Nixtla Anomaly Streaming Monitor MCP server (PoC) running");
 }
 
 main().catch(console.error);

--- a/005-plugins/nixtla-anomaly-streaming-monitor/tests/conftest.py
+++ b/005-plugins/nixtla-anomaly-streaming-monitor/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Pytest fixtures for nixtla-anomaly-streaming-monitor tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def plugin_root():
+    return PLUGIN_ROOT
+
+
+@pytest.fixture
+def ts_server_source(plugin_root):
+    return (plugin_root / "src" / "mcp-server" / "index.ts").read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def readme_source(plugin_root):
+    return (plugin_root / "README.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def plugin_manifest(plugin_root):
+    import json
+
+    return json.loads((plugin_root / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))

--- a/005-plugins/nixtla-anomaly-streaming-monitor/tests/test_poc_labeling.py
+++ b/005-plugins/nixtla-anomaly-streaming-monitor/tests/test_poc_labeling.py
@@ -1,0 +1,148 @@
+"""Verify PoC labeling integrity for nixtla-anomaly-streaming-monitor.
+
+The MCP server is TypeScript (kafkajs / aws-sdk integration is the production
+target), so we don't run Node-runtime tests here. Instead, we assert that the
+plugin's PoC posture is consistent across:
+
+  - plugin.json (description, version)
+  - README.md (banner, what's-real-vs-PoC matrix)
+  - src/mcp-server/index.ts (every tool description prefixed [PoC],
+    every tool response carries _disclaimer)
+
+This is the contract a production drop-in replacement must preserve.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# plugin.json
+# ---------------------------------------------------------------------------
+
+
+class TestPluginManifest:
+    def test_version_is_poc(self, plugin_manifest):
+        assert "poc" in plugin_manifest["version"].lower()
+
+    def test_description_marks_poc(self, plugin_manifest):
+        assert "PROOF OF CONCEPT" in plugin_manifest["description"]
+
+    def test_canonical_fields_present(self, plugin_manifest):
+        for field in ("name", "version", "description", "author", "license", "keywords"):
+            assert field in plugin_manifest, f"missing canonical field: {field}"
+
+    def test_author_url_correct(self, plugin_manifest):
+        assert plugin_manifest["author"]["url"] == "https://github.com/jeremylongshore"
+
+    def test_keywords_include_poc(self, plugin_manifest):
+        assert "proof-of-concept" in plugin_manifest["keywords"]
+
+
+# ---------------------------------------------------------------------------
+# README.md
+# ---------------------------------------------------------------------------
+
+
+class TestReadme:
+    def test_has_proof_of_concept_banner(self, readme_source):
+        assert "**PROOF OF CONCEPT" in readme_source
+
+    def test_has_origin_section(self, readme_source):
+        assert "## Origin" in readme_source
+
+    def test_has_whats_real_vs_poc_section(self, readme_source):
+        assert "What's real vs PoC" in readme_source
+
+    def test_lists_all_six_tools(self, readme_source):
+        for tool in (
+            "stream_monitor_start",
+            "stream_monitor_stop",
+            "stream_health_check",
+            "configure_alerts",
+            "get_anomaly_stats",
+            "export_dashboard_config",
+        ):
+            assert tool in readme_source, f"README missing tool: {tool}"
+
+
+# ---------------------------------------------------------------------------
+# index.ts (TypeScript MCP server)
+# ---------------------------------------------------------------------------
+
+
+class TestTypescriptServer:
+    def test_has_module_poc_disclaimer(self, ts_server_source):
+        assert "PROOF OF CONCEPT" in ts_server_source
+        assert "POC_DISCLAIMER" in ts_server_source
+
+    def test_version_string_is_poc(self, ts_server_source):
+        # version: "1.0.0-poc" or similar
+        assert re.search(
+            r'version:\s*"[^"]*-poc"', ts_server_source
+        ), "TS server version should carry -poc suffix"
+
+    def test_every_tool_description_marked_poc(self, ts_server_source):
+        # Find all `description: "..."` fields. Every Tool object's description
+        # in the listTools output should start with `[PoC]`.
+        # Match `description: "[PoC] ..."` patterns inside the Tool array.
+        tool_blocks = re.findall(r'name:\s*"(\w+)",\s*description:\s*"([^"]+)"', ts_server_source)
+        # Filter to tool-array entries (the property descriptions inside
+        # inputSchema also match name+description but we want top-level Tool
+        # objects only). Easiest filter: at least one is named like a tool.
+        tool_names = {
+            "stream_monitor_start",
+            "stream_monitor_stop",
+            "stream_health_check",
+            "configure_alerts",
+            "get_anomaly_stats",
+            "export_dashboard_config",
+        }
+        tool_descs = [(n, d) for n, d in tool_blocks if n in tool_names]
+        assert len(tool_descs) == 6, f"expected 6 tools, got {len(tool_descs)}: {tool_descs}"
+        for name, desc in tool_descs:
+            assert desc.startswith("[PoC]"), f"{name} description not [PoC]-prefixed: {desc}"
+
+    def test_every_response_carries_disclaimer(self, ts_server_source):
+        # Each `case "<name>":` branch should reference `POC_DISCLAIMER` (or
+        # `_disclaimer:`) within its return.
+        tool_names = [
+            "stream_monitor_start",
+            "stream_monitor_stop",
+            "stream_health_check",
+            "configure_alerts",
+            "get_anomaly_stats",
+            "export_dashboard_config",
+        ]
+        for name in tool_names:
+            # Find the case block.
+            pattern = rf'case "{name}":(.*?)(?=case "|default:)'
+            match = re.search(pattern, ts_server_source, re.DOTALL)
+            assert match, f"missing case block for {name}"
+            block = match.group(1)
+            assert (
+                "POC_DISCLAIMER" in block or "_disclaimer" in block
+            ), f"{name} response missing POC_DISCLAIMER / _disclaimer field"
+
+
+# ---------------------------------------------------------------------------
+# Cross-artifact consistency
+# ---------------------------------------------------------------------------
+
+
+class TestConsistency:
+    def test_plugin_name_matches_directory(self, plugin_manifest, plugin_root):
+        assert plugin_manifest["name"] == plugin_root.name
+
+    def test_repository_url_consistent(self, plugin_manifest, readme_source):
+        # README should reference the owner (case-insensitive — README author name
+        # is "Jeremy Longshore", plugin.json owner URL is github.com/jeremylongshore).
+        readme_lower = readme_source.lower()
+        assert (
+            plugin_manifest["repository"].lower() in readme_lower
+            or "jeremy longshore" in readme_lower
+            or "jeremylongshore" in readme_lower
+        ), "README should reference the plugin owner / repo URL"


### PR DESCRIPTION
Closes Epic 3.2. Per principal direction: streaming-monitor kept as PoC with honest labeling.

- **README**: PROOF OF CONCEPT banner, Origin, What's-real-vs-PoC matrix per tool
- **TS MCP server**: POC_DISCLAIMER constant, every tool prefixed `[PoC]`, every response carries `_disclaimer`
- **plugin.json**: 0.1.0 → 1.0.0-poc; [PROOF OF CONCEPT] in description
- **15 Python tests** verifying PoC labeling integrity across plugin.json + README + index.ts
- **Per-plugin CI** with pytest + validator marketplace tier

**Gates green**: 15/15 tests, validator zero errors, black + isort clean.

Anchored: `000-docs/131-AT-PLAN-plugin-build-roadmap.md` Phase 3 / Epic 3.2.