### PR TITLE
feat(snowflake-adapter): v1.0 (Epic 2.3)

### DIFF
--- a/.github/workflows/nixtla-snowflake-adapter-ci.yml
+++ b/.github/workflows/nixtla-snowflake-adapter-ci.yml
@@ -1,0 +1,79 @@
+name: Nixtla Snowflake Adapter CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '005-plugins/nixtla-snowflake-adapter/**'
+      - '.github/workflows/nixtla-snowflake-adapter-ci.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '005-plugins/nixtla-snowflake-adapter/**'
+      - '.github/workflows/nixtla-snowflake-adapter-ci.yml'
+
+jobs:
+  unit-tests:
+    name: Unit Tests (pytest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 005-plugins/nixtla-snowflake-adapter
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest mcp
+          # snowflake-connector-python is a heavy install and is NOT
+          # required for unit tests (the SQL generators are pure Python +
+          # the MCP dispatch is offline). Skip it here.
+
+      - name: Run pytest
+        # Override repo-root pytest.ini addopts (which inject --cov flags) so
+        # the per-plugin job runs in isolation.
+        run: pytest tests/ -v -o addopts="" -p no:cacheprovider
+
+  validator-gate:
+    name: Plugin Validator v7.0 (marketplace tier)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+        with:
+          path: plugins-nixtla
+
+      - name: Checkout claude-code-plugins
+        uses: actions/checkout@v4
+        with:
+          repository: jeremylongshore/claude-code-plugins
+          path: claude-code-plugins
+          ref: main
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install validator deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml jsonschema
+
+      - name: Validate (marketplace tier)
+        run: |
+          python claude-code-plugins/scripts/validate-skills-schema.py \
+            --marketplace \
+            plugins-nixtla/005-plugins/nixtla-snowflake-adapter/ \
+          || (echo "::error::Validator failed for nixtla-snowflake-adapter." && exit 1)

--- a/005-plugins/nixtla-snowflake-adapter/.claude-plugin/plugin.json
+++ b/005-plugins/nixtla-snowflake-adapter/.claude-plugin/plugin.json
@@ -1,8 +1,25 @@
 {
   "name": "nixtla-snowflake-adapter",
-  "description": "Claude Code wrapper for Nixtla Snowflake Native App. Generate CALL NIXTLA_FORECAST() SQL and validate installations.",
-  "version": "0.1.0",
+  "version": "1.0.0",
+  "description": "Generate CALL NIXTLA.FORECAST() / NIXTLA.DETECT_ANOMALIES() SQL for the Nixtla Snowflake Native App, validate installation, and emit Looker views — all from inside Claude Code.",
   "author": {
-    "name": "Intent Solutions"
-  }
+    "name": "Jeremy Longshore",
+    "email": "jeremy@intentsolutions.io",
+    "url": "https://github.com/jeremylongshore"
+  },
+  "homepage": "https://github.com/jeremylongshore/plugins-nixtla",
+  "repository": "https://github.com/jeremylongshore/plugins-nixtla",
+  "license": "MIT",
+  "keywords": [
+    "nixtla",
+    "snowflake",
+    "native-app",
+    "sql",
+    "forecasting",
+    "time-series",
+    "anomaly-detection",
+    "looker"
+  ],
+  "commands": "./commands",
+  "mcpServers": "./.mcp.json"
 }

--- a/005-plugins/nixtla-snowflake-adapter/tests/conftest.py
+++ b/005-plugins/nixtla-snowflake-adapter/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest fixtures for nixtla-snowflake-adapter."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = PLUGIN_ROOT / "scripts"
+
+# Make scripts/snowflake_mcp.py importable.
+sys.path.insert(0, str(SCRIPTS_DIR))

--- a/005-plugins/nixtla-snowflake-adapter/tests/test_sql_generators.py
+++ b/005-plugins/nixtla-snowflake-adapter/tests/test_sql_generators.py
@@ -16,14 +16,12 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
 from snowflake_mcp import (
     call_tool,
     generate_forecast_sql,
     generate_setup_validation_sql,
     list_tools,
 )
-
 
 # ---------------------------------------------------------------------------
 # generate_forecast_sql
@@ -156,9 +154,7 @@ class TestCallToolDispatch:
         assert "SHOW APPLICATIONS LIKE 'NIXTLA%'" in result[0].text
 
     def test_anomaly_sql_includes_level(self):
-        result = asyncio.run(
-            call_tool("generate_anomaly_sql", {"table": "metrics", "level": 99})
-        )
+        result = asyncio.run(call_tool("generate_anomaly_sql", {"table": "metrics", "level": 99}))
         assert "DETECT_ANOMALIES" in result[0].text
         assert "INPUT_TABLE => 'metrics'" in result[0].text
         assert "LEVEL => 99" in result[0].text

--- a/005-plugins/nixtla-snowflake-adapter/tests/test_sql_generators.py
+++ b/005-plugins/nixtla-snowflake-adapter/tests/test_sql_generators.py
@@ -1,0 +1,205 @@
+"""Pytest tests for the snowflake-adapter SQL generators + MCP dispatch.
+
+These tests cover the deterministic, offline surface of the plugin:
+
+  - generate_forecast_sql() with and without group_by_col
+  - generate_setup_validation_sql() invariants
+  - call_tool() dispatch for all four tool names
+  - list_tools() shape
+
+Integration tests against an actual Snowflake account live under
+tests/integration/ (created later when an account is wired up); they
+are NOT part of this default pytest run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from snowflake_mcp import (
+    call_tool,
+    generate_forecast_sql,
+    generate_setup_validation_sql,
+    list_tools,
+)
+
+
+# ---------------------------------------------------------------------------
+# generate_forecast_sql
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateForecastSQL:
+    def test_minimal_args(self):
+        sql = generate_forecast_sql(table="sales")
+        # Required: NIXTLA.FORECAST CALL with the table interpolated.
+        assert "CALL NIXTLA.FORECAST(" in sql
+        assert "INPUT_TABLE => 'sales'" in sql
+
+    def test_default_columns_and_horizon(self):
+        sql = generate_forecast_sql(table="sales")
+        assert "TIMESTAMP_COL => 'ds'" in sql
+        assert "VALUE_COL => 'y'" in sql
+        assert "HORIZON => 30" in sql
+        assert "FREQUENCY => 'D'" in sql
+
+    def test_group_by_emits_clause_and_results_order(self):
+        sql = generate_forecast_sql(table="sales", group_by_col="store")
+        assert "GROUP_BY_COL => 'store'" in sql
+        # Results-ordering should include the group key.
+        assert "ORDER BY 'store', FORECAST_DATE" in sql
+
+    def test_no_group_by_omits_clause(self):
+        sql = generate_forecast_sql(table="sales")
+        assert "GROUP_BY_COL" not in sql
+        assert "ORDER BY FORECAST_DATE" in sql
+
+    def test_custom_levels_serialized_to_array(self):
+        sql = generate_forecast_sql(table="sales", levels=[50, 80])
+        assert "LEVEL => ARRAY_CONSTRUCT(50, 80)" in sql
+
+    def test_default_levels_80_90_95(self):
+        sql = generate_forecast_sql(table="sales")
+        assert "LEVEL => ARRAY_CONSTRUCT(80, 90, 95)" in sql
+
+    def test_custom_columns_and_freq(self):
+        sql = generate_forecast_sql(
+            table="hourly_traffic",
+            timestamp_col="event_ts",
+            value_col="visits",
+            horizon=72,
+            freq="H",
+        )
+        assert "INPUT_TABLE => 'hourly_traffic'" in sql
+        assert "TIMESTAMP_COL => 'event_ts'" in sql
+        assert "VALUE_COL => 'visits'" in sql
+        assert "HORIZON => 72" in sql
+        assert "FREQUENCY => 'H'" in sql
+
+    def test_includes_results_select(self):
+        sql = generate_forecast_sql(table="sales")
+        assert "SELECT *" in sql
+        assert "NIXTLA.FORECAST_RESULTS" in sql
+
+
+# ---------------------------------------------------------------------------
+# generate_setup_validation_sql
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSetupValidationSQL:
+    def test_returns_non_empty_string(self):
+        sql = generate_setup_validation_sql()
+        assert isinstance(sql, str)
+        assert len(sql) > 100
+
+    def test_includes_all_validation_checks(self):
+        sql = generate_setup_validation_sql()
+        # The validation script must check (a) app installed, (b) grants,
+        # (c) function definitions, and (d) run a smoke forecast.
+        assert "SHOW APPLICATIONS LIKE 'NIXTLA%'" in sql
+        assert "SHOW GRANTS ON APPLICATION NIXTLA" in sql
+        assert "DESCRIBE FUNCTION NIXTLA.FORECAST" in sql
+        assert "DESCRIBE FUNCTION NIXTLA.DETECT_ANOMALIES" in sql
+        assert "DESCRIBE FUNCTION NIXTLA.CROSS_VALIDATE" in sql
+        assert "CALL NIXTLA.FORECAST(" in sql
+
+    def test_cleans_up_test_data(self):
+        sql = generate_setup_validation_sql()
+        assert "DROP TABLE IF EXISTS test_data" in sql
+
+
+# ---------------------------------------------------------------------------
+# list_tools (MCP surface)
+# ---------------------------------------------------------------------------
+
+
+class TestListTools:
+    def test_returns_four_tools(self):
+        tools = asyncio.run(list_tools())
+        assert len(tools) == 4
+
+    def test_tool_names(self):
+        tools = asyncio.run(list_tools())
+        names = {t.name for t in tools}
+        assert names == {
+            "generate_forecast_sql",
+            "validate_setup",
+            "generate_anomaly_sql",
+            "export_looker_view",
+        }
+
+    def test_forecast_sql_tool_requires_table(self):
+        tools = asyncio.run(list_tools())
+        forecast = next(t for t in tools if t.name == "generate_forecast_sql")
+        assert "table" in forecast.inputSchema["required"]
+
+
+# ---------------------------------------------------------------------------
+# call_tool (MCP dispatch)
+# ---------------------------------------------------------------------------
+
+
+class TestCallToolDispatch:
+    def test_generate_forecast_sql_through_dispatch(self):
+        result = asyncio.run(
+            call_tool("generate_forecast_sql", {"table": "demo_table", "horizon": 14})
+        )
+        assert len(result) == 1
+        assert result[0].type == "text"
+        assert "INPUT_TABLE => 'demo_table'" in result[0].text
+        assert "HORIZON => 14" in result[0].text
+
+    def test_validate_setup_through_dispatch(self):
+        result = asyncio.run(call_tool("validate_setup", {}))
+        assert "SHOW APPLICATIONS LIKE 'NIXTLA%'" in result[0].text
+
+    def test_anomaly_sql_includes_level(self):
+        result = asyncio.run(
+            call_tool("generate_anomaly_sql", {"table": "metrics", "level": 99})
+        )
+        assert "DETECT_ANOMALIES" in result[0].text
+        assert "INPUT_TABLE => 'metrics'" in result[0].text
+        assert "LEVEL => 99" in result[0].text
+        # Default columns when not provided
+        assert "TIMESTAMP_COL => 'ds'" in result[0].text
+        assert "VALUE_COL => 'y'" in result[0].text
+
+    def test_anomaly_sql_default_level(self):
+        result = asyncio.run(call_tool("generate_anomaly_sql", {"table": "metrics"}))
+        assert "LEVEL => 95" in result[0].text
+
+    def test_export_looker_view_default_name(self):
+        result = asyncio.run(call_tool("export_looker_view", {}))
+        text = result[0].text
+        assert "view: nixtla_forecasts {" in text
+        assert "NIXTLA.FORECAST_RESULTS" in text
+
+    def test_export_looker_view_custom_name(self):
+        result = asyncio.run(call_tool("export_looker_view", {"view_name": "weekly_sales_fc"}))
+        assert "view: weekly_sales_fc {" in result[0].text
+
+    def test_unknown_tool_returns_text_message(self):
+        result = asyncio.run(call_tool("totally_fake", {}))
+        assert "Unknown tool" in result[0].text
+        assert "totally_fake" in result[0].text
+
+
+# ---------------------------------------------------------------------------
+# Defensive checks against accidental SQL injection in args
+# ---------------------------------------------------------------------------
+
+
+class TestArgumentEscaping:
+    """The generators trust caller input — these tests document that contract.
+
+    If escaping is added later, these tests should still pass: the generated
+    SQL must continue to embed the table name verbatim. The point is to
+    surface drift rather than block insecure behavior; production use should
+    parameterize via Snowflake bind variables.
+    """
+
+    def test_table_name_passes_through_verbatim(self):
+        sql = generate_forecast_sql(table="weird-but-quoted_table")
+        assert "INPUT_TABLE => 'weird-but-quoted_table'" in sql


### PR DESCRIPTION
Closes Epic 2.3 (`nixtla-0pn`). snowflake-adapter v0.1.0 → v1.0.

- **plugin.json**: canonical 8-field IS set; Intent Solutions → Jeremy Longshore
- **22 pytest unit tests** (new — none existed): SQL generator coverage with asymmetric inputs (group_by present/absent, custom levels, custom freq), MCP dispatch contract for all 4 tools, escaping pass-through
- **Per-plugin CI**: pytest + Plugin Validator v7.0 marketplace tier
- **Integration tests note**: snowflake-connector-python is intentionally NOT installed in CI; integration tests against a real Snowflake account belong under `tests/integration/` (created when an account is wired up)

**Gates green**: validator zero errors, 22/22 tests pass in 0.63s.

Anchored: `000-docs/131-AT-PLAN-plugin-build-roadmap.md` Phase 2 / Epic 2.3.