### PR TITLE
fix(docs): consistency sync after repo transfer + post-Phase-2 reality

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,44 +2,63 @@
   "name": "nixtla-plugins",
   "owner": {
     "name": "Intent Solutions",
-    "url": "https://github.com/intent-solutions-io"
+    "url": "https://github.com/jeremylongshore"
   },
   "plugins": [
     {
       "name": "nixtla-baseline-lab",
       "version": "1.5.0",
-      "source": "github:intent-solutions-io/plugins-nixtla/005-plugins/nixtla-baseline-lab",
+      "source": "github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-baseline-lab",
       "description": "Run Nixtla-style baseline forecasting models on public benchmark datasets from inside Claude Code conversations.",
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
       "category": "time-series-forecasting",
-      "tags": ["nixtla", "statsforecast", "time-series", "forecasting", "m4", "benchmarks"]
+      "tags": [
+        "nixtla",
+        "statsforecast",
+        "time-series",
+        "forecasting",
+        "m4",
+        "benchmarks"
+      ]
     },
     {
       "name": "nixtla-bigquery-forecaster",
       "version": "0.1.0",
-      "source": "github:intent-solutions-io/plugins-nixtla/005-plugins/nixtla-bigquery-forecaster",
+      "source": "github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-bigquery-forecaster",
       "description": "Run Nixtla statsforecast models on BigQuery time series data. Pull from BigQuery, forecast with AutoETS/AutoTheta, write results back.",
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
       "category": "time-series-forecasting",
-      "tags": ["nixtla", "bigquery", "google-cloud", "statsforecast", "time-series"]
+      "tags": [
+        "nixtla",
+        "bigquery",
+        "google-cloud",
+        "statsforecast",
+        "time-series"
+      ]
     },
     {
       "name": "nixtla-search-to-slack",
-      "version": "0.2.0",
-      "source": "github:intent-solutions-io/plugins-nixtla/005-plugins/nixtla-search-to-slack",
+      "version": "1.0.0",
+      "source": "github:jeremylongshore/plugins-nixtla/005-plugins/nixtla-search-to-slack",
       "description": "Automated content discovery and curation for Nixtla and time-series forecasting practitioners. Searches web and GitHub, generates AI summaries, and publishes formatted digests to Slack.",
       "author": {
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
       "category": "productivity",
-      "tags": ["nixtla", "slack", "automation", "content-curation", "timegpt"]
+      "tags": [
+        "nixtla",
+        "slack",
+        "automation",
+        "content-curation",
+        "timegpt"
+      ]
     }
   ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
     "nixtla-dev-marketplace": {
       "source": {
         "source": "github",
-        "repo": "intent-solutions-io/plugins-nixtla"
+        "repo": "jeremylongshore/plugins-nixtla"
       }
     }
   },

--- a/.gist-id
+++ b/.gist-id
@@ -1,0 +1,1 @@
+dcdd7d8a9a262ec1f556fcb60b7af4f9

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussions
-    url: https://github.com/intent-solutions-io/plugins-nixtla/discussions
+    url: https://github.com/jeremylongshore/plugins-nixtla/discussions
     about: Ask questions and discuss ideas with the community
   - name: Intent Solutions IO Support
     url: mailto:jeremy@intentsolutions.io

--- a/000-docs/000a-planned-plugins/implemented/nixtla-search-to-slack/04-USER-JOURNEY.md
+++ b/000-docs/000a-planned-plugins/implemented/nixtla-search-to-slack/04-USER-JOURNEY.md
@@ -10,7 +10,7 @@
 ### Step 1: Clone and Setup Environment
 
 ```bash
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
 cd plugins-nixtla/005-plugins/nixtla-search-to-slack
 
 python -m venv venv

--- a/000-docs/097-AA-AUDT-appaudit-devops-playbook.md
+++ b/000-docs/097-AA-AUDT-appaudit-devops-playbook.md
@@ -989,7 +989,7 @@ git push -u origin feature/my-feature
 
 - **Repository Owner**: Jeremy Longshore (Intent Solutions)
 - **Nixtla Contact**: [TBD based on collaboration]
-- **GitHub Issues**: https://github.com/intent-solutions-io/plugins-nixtla/issues
+- **GitHub Issues**: https://github.com/jeremylongshore/plugins-nixtla/issues
 
 ---
 

--- a/000-docs/6767-a-OD-ARCH-nixtla-claude-plugin-poc-baseline-lab.md
+++ b/000-docs/6767-a-OD-ARCH-nixtla-claude-plugin-poc-baseline-lab.md
@@ -103,10 +103,10 @@ The manifest defines plugin metadata and component locations.
     "email": "jeremy@intentsolutions.io",
     "url": "https://github.com/jeremylongshore"
   },
-  "homepage": "https://github.com/intent-solutions-io/plugins-nixtla",
+  "homepage": "https://github.com/jeremylongshore/plugins-nixtla",
   "repository": {
     "type": "git",
-    "url": "https://github.com/intent-solutions-io/plugins-nixtla.git"
+    "url": "https://github.com/jeremylongshore/plugins-nixtla.git"
   },
   "license": "MIT",
   "keywords": [

--- a/000-docs/6767-b-PP-PLAN-nixtla-claude-plugin-poc-baseline-lab.md
+++ b/000-docs/6767-b-PP-PLAN-nixtla-claude-plugin-poc-baseline-lab.md
@@ -419,7 +419,7 @@ After PoC validation, this plugin can expand to:
 
 - **Project Lead**: Jeremy Longshore (jeremy@intentsolutions.io)
 - **Nixtla Collaboration**: Max Mergenthaler (max@nixtla.io)
-- **Repository**: https://github.com/intent-solutions-io/plugins-nixtla
+- **Repository**: https://github.com/jeremylongshore/plugins-nixtla
 
 ---
 

--- a/000-docs/6767-c-OD-OVRV-nixtla-baseline-lab-product-overview.md
+++ b/000-docs/6767-c-OD-OVRV-nixtla-baseline-lab-product-overview.md
@@ -216,7 +216,7 @@ The **Nixtla Baseline Lab** is a production-ready Claude Code plugin that brings
 **1. Initial Setup** (5 minutes)
 ```bash
 # Clone repo
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
 cd claude-code-plugins-nixtla
 
 # Open in Claude Code and trust folder
@@ -336,7 +336,7 @@ export NIXTLA_TIMEGPT_API_KEY="your-key"
 ## Contact & Support
 
 **Questions**: jeremy@intentsolutions.io or max@nixtla.io
-**Issues**: GitHub Issues on `intent-solutions-io/plugins-nixtla`
+**Issues**: GitHub Issues on `jeremylongshore/plugins-nixtla`
 **Documentation**: `005-plugins/nixtla-baseline-lab/README.md` (plugin manual)
 
 ---

--- a/000-docs/CONTRIBUTING.md
+++ b/000-docs/CONTRIBUTING.md
@@ -283,8 +283,8 @@ Examples:
 ### Getting Help
 
 - **Documentation**: Start with our [documentation](./000-docs/)
-- **Issues**: Search [existing issues](https://github.com/intent-solutions-io/plugins-nixtla/issues)
-- **Discussions**: Join our [GitHub Discussions](https://github.com/intent-solutions-io/plugins-nixtla/discussions)
+- **Issues**: Search [existing issues](https://github.com/jeremylongshore/plugins-nixtla/issues)
+- **Discussions**: Join our [GitHub Discussions](https://github.com/jeremylongshore/plugins-nixtla/discussions)
 - **Email**: Reach out to jeremy@intentsolutions.io
 
 ### Recognition

--- a/000-docs/FOR-MAX-QUICKSTART.md
+++ b/000-docs/FOR-MAX-QUICKSTART.md
@@ -22,7 +22,7 @@ Runs statsforecast baselines on M4 data. Fully offline, no API costs.
 
 ```bash
 # Clone and setup
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
 cd plugins-nixtla/plugins/nixtla-baseline-lab
 ./scripts/setup_nixtla_env.sh --venv
 source .venv-nixtla-baseline/bin/activate
@@ -150,4 +150,4 @@ jeremy@intentsolutions.io | 251.213.1115
 
 ---
 
-**Repository:** https://github.com/intent-solutions-io/plugins-nixtla
+**Repository:** https://github.com/jeremylongshore/plugins-nixtla

--- a/000-docs/PLUGIN_TREE.md
+++ b/000-docs/PLUGIN_TREE.md
@@ -220,7 +220,7 @@
 
 ```bash
 # Clone repository
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
 cd plugins-nixtla
 
 # Install baseline lab
@@ -287,7 +287,7 @@ See individual plugin READMEs for contribution guidelines:
 
 ## 📚 Additional Resources
 
-- **Main Repository**: [plugins-nixtla](https://github.com/intent-solutions-io/plugins-nixtla)
+- **Main Repository**: [plugins-nixtla](https://github.com/jeremylongshore/plugins-nixtla)
 - **Skills Documentation**: [003-skills/.claude/skills/](003-skills/.claude/skills/)
 - **Plugin Documentation**: [000-docs/002a-planned-plugins/](000-docs/002a-planned-plugins/)
 
@@ -301,4 +301,4 @@ See individual plugin READMEs for contribution guidelines:
 ---
 
 **Last Updated**: 2025-12-09
-**Repository**: https://github.com/intent-solutions-io/plugins-nixtla
+**Repository**: https://github.com/jeremylongshore/plugins-nixtla

--- a/003-skills/.claude/skills/nixtla-skills-bootstrap/resources/error-handling-guide.md
+++ b/003-skills/.claude/skills/nixtla-skills-bootstrap/resources/error-handling-guide.md
@@ -13,7 +13,7 @@ Installation Options:
 
 1. Development Mode (from repo):
    ```
-   git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+   git clone https://github.com/jeremylongshore/plugins-nixtla.git
    cd claude-code-plugins-nixtla
    pip install -e packages/nixtla-claude-skills-installer
    ```

--- a/003-skills/.claude/skills/nixtla-skills-bootstrap/resources/example-sessions.md
+++ b/003-skills/.claude/skills/nixtla-skills-bootstrap/resources/example-sessions.md
@@ -68,7 +68,7 @@ All skills are now up to date.
 The installer needs to be installed first:
 
 ```
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
 cd claude-code-plugins-nixtla
 pip install -e packages/nixtla-claude-skills-installer
 ```

--- a/005-plugins/nixtla-bigquery-forecaster/.claude-plugin/plugin.json
+++ b/005-plugins/nixtla-bigquery-forecaster/.claude-plugin/plugin.json
@@ -5,10 +5,10 @@
   "author": {
     "name": "Jeremy Longshore",
     "email": "jeremy@intentsolutions.io",
-    "url": "https://github.com/intent-solutions-io"
+    "url": "https://github.com/jeremylongshore"
   },
-  "homepage": "https://github.com/intent-solutions-io/plugins-nixtla",
-  "repository": "https://github.com/intent-solutions-io/plugins-nixtla",
+  "homepage": "https://github.com/jeremylongshore/plugins-nixtla",
+  "repository": "https://github.com/jeremylongshore/plugins-nixtla",
   "license": "MIT",
   "keywords": [
     "nixtla",

--- a/005-plugins/nixtla-bigquery-forecaster/000-docs/002-DR-QREF-max-quick-start-guide.md
+++ b/005-plugins/nixtla-bigquery-forecaster/000-docs/002-DR-QREF-max-quick-start-guide.md
@@ -18,7 +18,7 @@
 ## ✅ Prerequisites Checklist
 
 Before starting, make sure you have:
-- [ ] GitHub account access to `intent-solutions-io/plugins-nixtla`
+- [ ] GitHub account access to `jeremylongshore/plugins-nixtla`
 - [ ] TimeGPT API key (already have: `nixak-...`)
 - [ ] 5 minutes
 
@@ -28,7 +28,7 @@ That's it! No GCP account needed on your end. Jeremy set everything up.
 
 ## 🚀 Step 1: Configure GitHub Secrets (2 minutes)
 
-Go to: https://github.com/intent-solutions-io/plugins-nixtla/settings/secrets/actions
+Go to: https://github.com/jeremylongshore/plugins-nixtla/settings/secrets/actions
 
 Add these **4 secrets** (copy-paste from below):
 
@@ -70,7 +70,7 @@ git push origin main
 
 ## 👀 Step 3: Watch Deployment (2 minutes)
 
-Go to: https://github.com/intent-solutions-io/plugins-nixtla/actions
+Go to: https://github.com/jeremylongshore/plugins-nixtla/actions
 
 You'll see **"Deploy Nixtla BigQuery Forecaster"** workflow running.
 
@@ -220,8 +220,8 @@ Add `"include_timegpt": true` to the test payload:
 - **GCP Console**: https://console.cloud.google.com/home/dashboard?project=nixtla-playground-01
 - **Cloud Functions**: https://console.cloud.google.com/functions?project=nixtla-playground-01
 - **BigQuery**: https://console.cloud.google.com/bigquery?project=nixtla-playground-01
-- **GitHub Actions**: https://github.com/intent-solutions-io/plugins-nixtla/actions
-- **GitHub Secrets**: https://github.com/intent-solutions-io/plugins-nixtla/settings/secrets/actions
+- **GitHub Actions**: https://github.com/jeremylongshore/plugins-nixtla/actions
+- **GitHub Secrets**: https://github.com/jeremylongshore/plugins-nixtla/settings/secrets/actions
 
 ---
 

--- a/005-plugins/nixtla-bigquery-forecaster/SCHEMA-nixtla-bigquery-forecaster.md
+++ b/005-plugins/nixtla-bigquery-forecaster/SCHEMA-nixtla-bigquery-forecaster.md
@@ -47,8 +47,8 @@ nixtla-bigquery-forecaster/
 | description | Run Nixtla statsforecast models on BigQuery... | Required |
 | version | 0.1.0 | Required |
 | author.name | Jeremy Longshore | Required |
-| homepage | https://github.com/intent-solutions-io/plugins-nixtla | Optional |
-| repository | https://github.com/intent-solutions-io/plugins-nixtla | Optional |
+| homepage | https://github.com/jeremylongshore/plugins-nixtla | Optional |
+| repository | https://github.com/jeremylongshore/plugins-nixtla | Optional |
 | license | MIT | Optional |
 
 ---

--- a/005-plugins/nixtla-dbt-package/.claude-plugin/plugin.json
+++ b/005-plugins/nixtla-dbt-package/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Intent Solutions"
   },
   "license": "Apache-2.0",
-  "homepage": "https://github.com/intent-solutions-io/plugins-nixtla",
-  "repository": "https://github.com/intent-solutions-io/plugins-nixtla",
+  "homepage": "https://github.com/jeremylongshore/plugins-nixtla",
+  "repository": "https://github.com/jeremylongshore/plugins-nixtla",
   "keywords": ["dbt", "nixtla", "timegpt", "forecasting", "snowflake", "bigquery"]
 }

--- a/005-plugins/nixtla-dbt-package/commands/nixtla-dbt-setup.md
+++ b/005-plugins/nixtla-dbt-package/commands/nixtla-dbt-setup.md
@@ -12,7 +12,7 @@ Set up the Nixtla dbt package for TimeGPT forecasting.
 1. Add to packages.yml:
    ```yaml
    packages:
-     - git: "https://github.com/intent-solutions-io/plugins-nixtla.git"
+     - git: "https://github.com/jeremylongshore/plugins-nixtla.git"
        subdirectory: "005-plugins/nixtla-dbt-package"
    ```
 

--- a/006-packages/nixtla-claude-skills-installer/README.md
+++ b/006-packages/nixtla-claude-skills-installer/README.md
@@ -8,7 +8,7 @@ Per-project installation and update utility for Nixtla Claude Code skills.
 
 ```bash
 # Clone the nixtla repo
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
 cd claude-code-plugins-nixtla
 
 # Install in editable mode
@@ -152,7 +152,7 @@ rm -rf .claude/skills/nixtla-timegpt-lab
 
 **Solution**: Install in development mode from repo:
 ```bash
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
 cd claude-code-plugins-nixtla
 pip install -e packages/nixtla-claude-skills-installer
 ```
@@ -178,7 +178,7 @@ pip install -e packages/nixtla-claude-skills-installer
 
 ```bash
 # Clone repo
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
 cd claude-code-plugins-nixtla
 
 # Install in editable mode
@@ -223,6 +223,6 @@ Sponsored by Nixtla (Max Mergenthaler)
 
 ## Related
 
-- **Nixtla Repo**: https://github.com/intent-solutions-io/plugins-nixtla
+- **Nixtla Repo**: https://github.com/jeremylongshore/plugins-nixtla
 - **Nixtla Docs**: https://docs.nixtla.io
 - **Claude Code**: https://claude.ai/code

--- a/006-packages/nixtla-claude-skills-installer/pyproject.toml
+++ b/006-packages/nixtla-claude-skills-installer/pyproject.toml
@@ -22,9 +22,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/intent-solutions-io/plugins-nixtla"
-Repository = "https://github.com/intent-solutions-io/plugins-nixtla"
-Issues = "https://github.com/intent-solutions-io/plugins-nixtla/issues"
+Homepage = "https://github.com/jeremylongshore/plugins-nixtla"
+Repository = "https://github.com/jeremylongshore/plugins-nixtla"
+Issues = "https://github.com/jeremylongshore/plugins-nixtla/issues"
 
 [project.scripts]
 nixtla-skills = "nixtla_skills_installer.cli:main"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Attribute | Value |
 |-----------|-------|
 | **Version** | 1.9.0 (source: `VERSION`) |
-| **Status** | Experimental showcase |
+| **Status** | v1.9.0 — 12/13 plugins at v1.0 marketplace tier (or v1.0-poc with honest labeling) |
 | **Stack** | Python 3.10+ (Nixtla SDK >=0.7.3 dropped 3.9), statsforecast, TimeGPT API, pytest, black, isort |
 | **Skills** | 30 (in `003-skills/.claude/skills/`) |
-| **Plugins** | 13 (in `005-plugins/`) - 3 working |
+| **Plugins** | 13 (in `005-plugins/`) — 12 at v1.0 / v1.0-poc; `nixtla-bigquery-forecaster` + `nixtla-dbt-package` still in progress |
 
 ## Quick Start (5 Minutes)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Nixtla Plugin Showcase
+# plugins-nixtla v1.9.0
 
-Claude Code plugins and AI skills for time-series forecasting with Nixtla's statsforecast and TimeGPT.
+Claude Code plugins and AI skills for time-series forecasting with Nixtla's statsforecast, mlforecast, neuralforecast, and TimeGPT.
 
-**Version**: 1.7.0 | **Status**: Experimental | **Plugins**: 3 | **Skills**: 8
+**Version**: 1.9.0 | **Plugins**: 13 (12 at v1.0 / v1.0-poc, 2 in progress) | **Skills**: 30 | **Validation**: Plugin Validator v7.0 (marketplace tier) per plugin
+
+**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/dcdd7d8a9a262ec1f556fcb60b7af4f9) · [GitHub](https://github.com/jeremylongshore/plugins-nixtla) · [Nixtla SDK](https://github.com/Nixtla/nixtla)
 
 ---
 
@@ -10,11 +12,11 @@ Claude Code plugins and AI skills for time-series forecasting with Nixtla's stat
 
 | Question | Answer |
 |----------|--------|
-| **What** | Claude Code plugins + AI skills for time-series forecasting |
-| **Who** | Business showcase for Nixtla CEO |
-| **Status** | Experimental (not production) |
-| **Stack** | Python 3.10+, statsforecast, TimeGPT API |
-| **Entry Point** | `005-plugins/nixtla-baseline-lab/` |
+| **What** | 13 Claude Code plugins + 30 AI skills for time-series forecasting |
+| **Who** | Forecasting practitioners, analytics engineers, ML platform owners |
+| **Status** | v1.9.0 — 12/13 plugins at v1.0 marketplace tier (or v1.0-poc with honest labeling); per-plugin CI gates on every PR |
+| **Stack** | Python 3.10+, statsforecast 1.7+, nixtla SDK 0.7.3+ (TimeGPT), pytest, MCP |
+| **Entry Point** | `005-plugins/nixtla-baseline-lab/` (working offline baselines, no API key) |
 
 ---
 
@@ -25,7 +27,7 @@ Claude Code plugins and AI skills for time-series forecasting with Nixtla's stat
 python3 --version  # Need 3.10+
 
 # 2. Clone and install
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
 cd plugins-nixtla
 pip install -e . && pip install -r requirements-dev.txt
 
@@ -113,7 +115,7 @@ export LOCATION='us-central1'
 
 ```bash
 # Clone
-git clone https://github.com/intent-solutions-io/plugins-nixtla.git
+git clone https://github.com/jeremylongshore/plugins-nixtla.git
 cd plugins-nixtla
 
 # Install (editable + dev deps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-code-plugins-nixtla"
-version = "0.7.0"
+version = "1.9.0"
 description = "Claude Code plugins for Nixtla time series forecasting ecosystem"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -66,10 +66,10 @@ cloud = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/intent-solutions-io/plugins-nixtla"
-Documentation = "https://github.com/intent-solutions-io/plugins-nixtla/blob/main/README.md"
-Repository = "https://github.com/intent-solutions-io/plugins-nixtla.git"
-Issues = "https://github.com/intent-solutions-io/plugins-nixtla/issues"
+Homepage = "https://github.com/jeremylongshore/plugins-nixtla"
+Documentation = "https://github.com/jeremylongshore/plugins-nixtla/blob/main/README.md"
+Repository = "https://github.com/jeremylongshore/plugins-nixtla.git"
+Issues = "https://github.com/jeremylongshore/plugins-nixtla/issues"
 
 [tool.setuptools]
 packages = ["plugins", "tests"]


### PR DESCRIPTION
Resolves the 4 critical + 6 warning findings from `/validate-consistency`.

## Repo transfer drift (Critical)
26 live files updated `intent-solutions-io/plugins-nixtla` → `jeremylongshore/plugins-nixtla`. Historical files (CHANGELOG.md, `000-docs/000b-archive-001-096/`, `000-docs/archive/`, plugin README-ARCHIVE.md, regen test artifacts, dated skills-backup) preserved as release-record artifacts.

## Status drift (Critical)
- **README.md** title → `plugins-nixtla v1.9.0`; status row → real plugin/skill counts (13/30) and v1.0 framing; canonical `**Links:**` line added pointing to the gist one-pager + GitHub repo + Nixtla SDK.
- **CLAUDE.md** status + Plugins rows updated to reflect 12 at v1.0 / v1.0-poc; `bigquery-forecaster` + `dbt-package` still in progress.

## Version drift (Warning)
- `pyproject.toml` umbrella `version`: 0.7.0 → 1.9.0 (aligns with VERSION).
- `marketplace.json`: search-to-slack 0.2.0 → 1.0.0 (matches PR #23 ship state).

## Gist scoping
- `.gist-id` added at repo root (`dcdd7d8a9a262ec1f556fcb60b7af4f9`) so future `/gist-auditor` runs find this repo's project gist directly. Closes the missing-Project-Landing-gist finding (Issue #13 from gist-auditor).

## Deliberately deferred
- Per-plugin marketplace.json expansion to all 13 plugins
- `000-docs/000-INDEX.md` generation

Both deferred to the D1 health audit per CHANGELOG v1.9.0 ("F2 deliberately keeps the marketplace listing tight at WORKING-only").

**Gates**: validator unaffected (no plugin code touched), no test changes.