### PR TITLE
chore(ci): delete parked cron blocks from gemini-daily-audit and timegpt-real-smoke

### DIFF
--- a/.github/workflows/gemini-daily-audit.yml
+++ b/.github/workflows/gemini-daily-audit.yml
@@ -1,16 +1,6 @@
 name: Gemini Weekly Code Audit
 
-# =============================================================================
-# COST OPTIMIZATION: Changed from daily to weekly (Sunday 12:00 UTC)
-# This saves ~30 workflow minutes per week
-# Manual trigger still available for on-demand audits
-# =============================================================================
-
 on:
-  # schedule disabled — burns Actions minutes
-  # schedule:
-  #   # Weekly on Sunday at 6am CST = 12:00 UTC
-  #   - cron: '0 12 * * 0'
   workflow_dispatch:  # Manual trigger for on-demand audits
 
 jobs:

--- a/.github/workflows/timegpt-real-smoke.yml
+++ b/.github/workflows/timegpt-real-smoke.yml
@@ -1,11 +1,6 @@
 name: TimeGPT Real-API Smoke Test (Weekly)
 
 on:
-  # schedule disabled — burns Actions minutes
-  # # Weekly scheduled run (Sundays at 02:00 UTC)
-  # schedule:
-  #   - cron: '0 2 * * 0'
-
   # Allow manual triggering
   workflow_dispatch:
 


### PR DESCRIPTION
**What:** Delete the commented-out `schedule:`/`cron:` blocks (plus orphaned "schedule disabled" headers and the stale COST OPTIMIZATION banner describing the retired weekly cadence) from `gemini-daily-audit.yml` and `timegpt-real-smoke.yml`. Live `workflow_dispatch` triggers untouched.

**Why:** 2026-07-10 estate automation remediation — a commented cron block is a zombie: it looks like an automation, shows up in audits, and tempts silent re-enable. Git history preserves it; revival is a reviewed PR away.

**Refs:** intent-solutions-io/intent-os#42

- Jeremy Longshore
intentsolutions.io