### PR TITLE
fix(security): remove the live TimeGPT client key from six tracked files and close the gitignore hole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ yarn-error.log*
 
 # Environment files
 .env
+*.env
 .env.local
 .env.*.local
 .env.development

--- a/000-docs/000b-archive-001-096/009-AT-ARCH-plugin-01-nixtla-cost-optimizer.md
+++ b/000-docs/000b-archive-001-096/009-AT-ARCH-plugin-01-nixtla-cost-optimizer.md
@@ -251,7 +251,7 @@ echo "════════════════════════�
 vim ~/.claude/005-plugins/nixtla-cost-optimizer/.env
 
 # Add your Nixtla API key
-NIXTLA_API_KEY=nixak-JNfT4z4JQb9uK3gdAyiWYWSBELdt6iW0PmE0Sy3k8ETAInJkFSPp4gOfyAZrENcGOsKyTqfDmuLghVq9
+NIXTLA_API_KEY=${NIXTLA_TIMEGPT_API_KEY}
 ```
 
 ### Step 4: Restart Claude Code

--- a/000-docs/000b-archive-001-096/028-OD-GUID-gcp-setup-complete.md
+++ b/000-docs/000b-archive-001-096/028-OD-GUID-gcp-setup-complete.md
@@ -41,7 +41,7 @@ projects/859338910722/locations/global/workloadIdentityPools/github-pool/provide
 
 ### 4. `NIXTLA_TIMEGPT_API_KEY`
 ```
-nixak-JNfT4z4JQb9uK3gdAyiWYWSBELdt6iW0PmE0Sy3k8ETAInJkFSPp4gOfyAZrENcGOsKyTqfDmuLghVq9
+${NIXTLA_TIMEGPT_API_KEY}
 ```
 
 ---

--- a/000-docs/000b-archive-001-096/030-OD-GUID-nixtla-playground-setup.md
+++ b/000-docs/000b-archive-001-096/030-OD-GUID-nixtla-playground-setup.md
@@ -70,7 +70,7 @@ projects/123456789/locations/global/workloadIdentityPools/github-pool/providers/
 
 #### Secret 4: `NIXTLA_TIMEGPT_API_KEY`
 ```
-nixak-JNfT4z4JQb9uK3gdAyiWYWSBELdt6iW0PmE0Sy3k8ETAInJkFSPp4gOfyAZrENcGOsKyTqfDmuLghVq9
+${NIXTLA_TIMEGPT_API_KEY}
 ```
 (TimeGPT API key from Max)
 

--- a/004-scripts/configs/nixtla-playground-config.env
+++ b/004-scripts/configs/nixtla-playground-config.env
@@ -1,10 +1,11 @@
-# Nixtla Playground GCP Configuration  
-# Generated: Sat Nov 29 22:01:10 CST 2025
+# Nixtla Playground GCP Configuration (TEMPLATE — no live values)
+# Secrets are read from the environment; never commit a generated copy of this file.
+# Originally generated 2025-11-29 by 004-scripts/setup-gcp-nixtla-playground.sh; sanitised 2026-09-07.
 
 export GCP_PROJECT_ID="nixtla-playground-01"
 export GCP_SA_EMAIL="nixtla-github-deployer@nixtla-playground-01.iam.gserviceaccount.com"
 export GCP_WORKLOAD_IDENTITY_PROVIDER="projects/859338910722/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-export NIXTLA_TIMEGPT_API_KEY="nixak-JNfT4z4JQb9uK3gdAyiWYWSBELdt6iW0PmE0Sy3k8ETAInJkFSPp4gOfyAZrENcGOsKyTqfDmuLghVq9"
+export NIXTLA_TIMEGPT_API_KEY="${NIXTLA_TIMEGPT_API_KEY}"
 
 # For local development
 gcloud config set project "nixtla-playground-01"

--- a/004-scripts/setup-gcp-nixtla-playground.sh
+++ b/004-scripts/setup-gcp-nixtla-playground.sh
@@ -211,7 +211,7 @@ echo "3. GCP_WORKLOAD_IDENTITY_PROVIDER"
 echo "   Value: projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_NAME}/providers/${PROVIDER_NAME}"
 echo ""
 echo "4. NIXTLA_TIMEGPT_API_KEY (from Max)"
-echo "   Value: nixak-JNfT4z4JQb9uK3gdAyiWYWSBELdt6iW0PmE0Sy3k8ETAInJkFSPp4gOfyAZrENcGOsKyTqfDmuLghVq9"
+echo "   Value: ${NIXTLA_TIMEGPT_API_KEY}"
 echo ""
 echo "=========================================="
 echo ""
@@ -227,7 +227,7 @@ cat > "${CONFIG_FILE}" <<EOF
 export GCP_PROJECT_ID="${PROJECT_ID}"
 export GCP_SA_EMAIL="${SA_EMAIL}"
 export GCP_WORKLOAD_IDENTITY_PROVIDER="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_NAME}/providers/${PROVIDER_NAME}"
-export NIXTLA_TIMEGPT_API_KEY="nixak-JNfT4z4JQb9uK3gdAyiWYWSBELdt6iW0PmE0Sy3k8ETAInJkFSPp4gOfyAZrENcGOsKyTqfDmuLghVq9"
+export NIXTLA_TIMEGPT_API_KEY="${NIXTLA_TIMEGPT_API_KEY}"
 
 # For local development
 gcloud config set project "${PROJECT_ID}"

--- a/005-plugins/nixtla-bigquery-forecaster/000-docs/002-DR-QREF-max-quick-start-guide.md
+++ b/005-plugins/nixtla-bigquery-forecaster/000-docs/002-DR-QREF-max-quick-start-guide.md
@@ -49,7 +49,7 @@ projects/859338910722/locations/global/workloadIdentityPools/github-pool/provide
 
 ### Secret 4: `NIXTLA_TIMEGPT_API_KEY`
 ```
-nixak-JNfT4z4JQb9uK3gdAyiWYWSBELdt6iW0PmE0Sy3k8ETAInJkFSPp4gOfyAZrENcGOsKyTqfDmuLghVq9
+${NIXTLA_TIMEGPT_API_KEY}
 ```
 
 ---


### PR DESCRIPTION
## What

Replaces the literal Nixtla TimeGPT API key with `${NIXTLA_TIMEGPT_API_KEY}` in the six tracked files that carried it on `main`, and adds `*.env` to `.gitignore` so a generated `nixtla-playground-config.env` can never be committed again.

## Why

The key is a **client-issued credential** and it has been world-readable since commit `80af2c1` (2025-11-29). Verified 2026-09-07 during the conference-readiness security sweep, without printing the value:

| Check | Result |
|---|---|
| `curl -o /dev/null -w '%{http_code}' https://raw.githubusercontent.com/.../004-scripts/configs/nixtla-playground-config.env` | `200` |
| `curl -H "Authorization: Bearer <value>" https://api.nixtla.io/usage` | `200` — **the key still authenticates** |
| Tracked files carrying it on `origin/main` | 6 |
| GitHub secret scanning on this repo | was **disabled** (now enabled, with push protection) |

This repository is public and nothing was watching.

**Decision rationale:** chose sanitising HEAD plus a gitignore rule over a history rewrite, because a force-push does not recall the value from forks, clones, or GitHub's commit cache — rewriting would buy a false sense of closure. Rotation is the control that actually works, and it is the owner's action.

## Layers touched

Docs (3 archived guides + 1 quick-start), one operator script, one generated-config artifact now demoted to a template, and repo ignore rules. No plugin code, no CI logic.

## How it works

`004-scripts/setup-gcp-nixtla-playground.sh` previously baked the literal into both its operator summary and the config heredoc it writes; it now interpolates the environment variable, which is what the script's own prompt ("NIXTLA_TIMEGPT_API_KEY (from Max)") always intended. The tracked `004-scripts/configs/nixtla-playground-config.env` was a generated artifact that should never have been committed; it now carries a header saying it is a template with no live values. The `*.env` rule covers the exact path the script writes at the repository root, which the previous bare `.env` rule did not match.

## Verification and evidence

```
git grep -c -F <value> HEAD        # no matching files on this branch (was 6)
bash -n 004-scripts/setup-gcp-nixtla-playground.sh          # ok
shellcheck -S error 004-scripts/setup-gcp-nixtla-playground.sh   # ok
git check-ignore -v nixtla-playground-config.env           # .gitignore:48:*.env
rg -n 'nixtla-playground-config|setup-gcp-nixtla-playground' --glob '!*.md'   # only the script that writes it
```

## ⚠️ This PR does not make the key safe

The value remains in this repository's **history** and was **still live** when this PR was opened. Required owner action, which cannot be done from a shell:

1. Rotate the TimeGPT key in the Nixtla dashboard.
2. Refresh the `NIXTLA_TIMEGPT_API_KEY` GitHub Actions secret consumed by `timegpt-real-smoke.yml`.

Until both are done, treat the credential as public.

## Risk

Low. The only executable change makes a script read an environment variable instead of a hardcoded constant; if the variable is unset the script writes an empty value where it previously wrote a leaked one, which is the safer failure. This script targets a GCP project and the GCP estate was torn down 2026-07-09, so the path is already dead in practice.

## Operational impact

No env vars, migrations, dependencies, or deploy-order changes. One new ignore rule. Secret scanning and push protection were enabled on this repository out of band.

## Follow-up

- Rotation and Actions-secret refresh (owner) — tracked as the P0 under the estate audit epic.
- Decide whether the archived `000-docs/000b-archive-001-096/` GCP guides should be retired entirely now that GCP is decommissioned.

## Refs

intent-solutions-io/intent-os#581

- Jeremy Longshore
intentsolutions.io

https://claude.ai/code/session_01QtGV3WgHso1uER1SnHqxB9
